### PR TITLE
ProvsChalutier white bar indicates idle

### DIFF
--- a/fishy/engine/semifisher/fishing_mode.py
+++ b/fishy/engine/semifisher/fishing_mode.py
@@ -7,7 +7,7 @@ class State(Enum):
     HOOK = 60,
     STICK = 18,
     LOOK = 100,
-    IDLE = -1
+    IDLE = 0
 
 
 def _notify(event):


### PR DESCRIPTION
This PR detects the white bar from Provisions Chalutier AddOn when idle, instead of hidden bar.
It will allow fishy to set the engine state to idle accordingly.

For me this fixed some hickups when running around with fishy engine on.
I think you can keep semifisher on the whole time now, while playing.

### Testing:
- Delete your ProvChalutier Addon. Reinstall from https://github.com/fishyboteso/ProvisionsChalutier
- go fishing, run around