### PR TITLE
Disallow numpy version 1.19.4 as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 urllib3
 winshell
 imutils
-numpy==1.19.3
+numpy!=1.19.4
 opencv_python
 Pillow
 pypiwin32


### PR DESCRIPTION
This PR ensures numpy versions other than 1.19.4 as a requirement for fishy.
Numpy Version 1.19.4 introduced a bug on windows making fishy not executable. This problem is now fixed in 1.19.5 and was not present before in 1.19.3.

Therefore this PR excludes 1.19.4 from the requirements.txt