### PR TITLE
Auto-Update: Add user interaction before updating (0.4.4)

### DIFF
--- a/fishy/__main__.py
+++ b/fishy/__main__.py
@@ -70,10 +70,10 @@ def main():
 
     hotkey.initalize()
 
-    gui_window.start()
-
     logging.info(f"Fishybot v{fishy.__version__}")
     initialize(window_to_hide)
+
+    gui_window.start()
 
     bot.start_event_handler()
 

--- a/fishy/__main__.py
+++ b/fishy/__main__.py
@@ -9,7 +9,7 @@ import win32gui
 import fishy
 from fishy import web, helper, gui
 from fishy.engine.common.event_handler import EngineEventHandler
-from fishy.gui import GUI, splash
+from fishy.gui import GUI, splash, update_dialog
 from fishy.helper import hotkey
 from fishy.helper.config import config
 
@@ -36,12 +36,20 @@ def initialize(window_to_hide):
         is_admin = os.getuid() == 0
     except AttributeError:
         is_admin = ctypes.windll.shell32.IsUserAnAdmin() != 0
-
     if is_admin:
         logging.info("Running with admin privileges")
 
     try:
-        helper.auto_upgrade()
+        if helper.upgrade_avail() and not config.get("dont_ask_update", False):
+            cv,hv = helper.versions()
+            update_now, dont_ask_update = update_dialog.start(cv,hv)
+            if dont_ask_update:
+                config.set("dont_ask_update", dont_ask_update)
+            else:
+                config.delete("dont_ask_update")
+
+            if update_now:
+                helper.auto_upgrade()
     except Exception:
         logging.error(traceback.format_exc())
 

--- a/fishy/engine/semifisher/fishing_event.py
+++ b/fishy/engine/semifisher/fishing_event.py
@@ -32,6 +32,7 @@ class FishEvent:
 
     # initialize these
     action_key = 'e'
+    collect_key = 'r' 
     collect_allow_auto = False
     sound = False
 

--- a/fishy/gui/main_gui.py
+++ b/fishy/gui/main_gui.py
@@ -55,6 +55,8 @@ def _create(gui: 'GUI'):
     dark_mode_var.set(int(config.get('dark_mode', True)))
     filemenu.add_checkbutton(label="Dark Mode", command=_toggle_mode,
                              variable=dark_mode_var)
+    if config.get("dont_ask_update", False):
+        filemenu.add_command(label="Update", command=helper.update)
 
     menubar.add_cascade(label="Options", menu=filemenu)
 

--- a/fishy/gui/splash.py
+++ b/fishy/gui/splash.py
@@ -3,24 +3,30 @@ from multiprocessing import Process
 from tkinter import *
 from PIL import Image, ImageTk
 
+from fishy.helper.config import config
 from fishy.helper import helper
 
 
 def show():
+    dim=(300,200)
     top = Tk()
 
-    # top.overrideredirect(True)
-    # top.lift()
+    top.overrideredirect(True)
+    top.lift()
 
     top.title("Loading...")
     top.resizable(False, False)
     top.iconbitmap(helper.manifest_file('icon.ico'))
 
-    canvas = Canvas(top, width=300, height=200)
+    canvas = Canvas(top, width=dim[0], height=dim[1], bg='white')
     canvas.pack()
-    top.image = Image.open(helper.manifest_file('fishybot_logo.png')).resize((300, 200))
+    top.image = Image.open(helper.manifest_file('fishybot_logo.png')).resize(dim)
     top.image = ImageTk.PhotoImage(top.image)
     canvas.create_image(0, 0, anchor=NW, image=top.image)
+
+    # Position splash at the center of the main window
+    win_loc = config.get("win_loc", str(top.winfo_reqwidth())+"+"+str(top.winfo_reqheight())+"+"+"0"+"0").split("+")[1:]
+    top.geometry("{}x{}+{}+{}".format(dim[0], dim[1], int(win_loc[0])+int(dim[0]/2), int(win_loc[1])+int(dim[1]/2)))
 
     top.update()
     time.sleep(3)

--- a/fishy/gui/update_dialog.py
+++ b/fishy/gui/update_dialog.py
@@ -1,0 +1,43 @@
+from multiprocessing import Process, Manager
+from tkinter import *
+import time
+
+def show(currentversion, newversion, returns):
+    top = Tk()
+    top.title("A wild update appears!")
+
+    dialogLabel = Label(top, text="There is a new update available ("+currentversion+"->"+newversion+"). Do you want to update now?")
+    dialogLabel.grid(row=0, columnspan=2, padx=5, pady=5)
+
+    cbVar = IntVar()
+    dialogCheckbutton = Checkbutton(top, text="don't ask again", variable=cbVar)
+    dialogCheckbutton.grid(row=1, columnspan=2, padx=5, pady=0)
+    top.update()
+    buttonWidth = int(dialogLabel.winfo_width()/2)-20
+
+    def _clickYes():
+        returns[0],returns[1]=True, False
+        top.destroy()
+
+    def _clickNo():
+        returns[0],returns[1]=False, bool(cbVar.get())
+        top.destroy()
+
+    pixelVirtual = PhotoImage(width=1, height=1) # trick to use buttonWidth as pixels, not #symbols
+    dialogBtnYes = Button(top, text="Yes " + str(chr(10003)),  fg='green', command=_clickYes, image=pixelVirtual, width=buttonWidth, compound="c")
+    dialogBtnYes.grid(row=2, column=0, padx=5, pady=5)
+    dialogBtnNo = Button(top, text="No " + str(chr(10005)),  fg='red', command=_clickNo, image=pixelVirtual, width=buttonWidth, compound="c")
+    dialogBtnNo.grid(row=2, column=1, padx=5, pady=5)
+
+    top.protocol('WM_DELETE_WINDOW', _clickNo)
+
+    top.update()
+    top.mainloop()
+
+
+def start(currentversion, newversion):
+    returns = Manager().dict()
+    p = Process(target=show, args=(currentversion, newversion, returns))
+    p.start()
+    p.join()
+    return returns[0], returns[1]

--- a/fishy/helper/__init__.py
+++ b/fishy/helper/__init__.py
@@ -1,4 +1,4 @@
 from .auto_update import auto_upgrade, upgrade_avail, versions
 from .config import Config
 from .helper import open_web, initialize_uid, install_thread_excepthook, unhandled_exception_logging, manifest_file, \
-    create_shortcut_first, check_addon, restart, create_shortcut, not_implemented
+    create_shortcut_first, check_addon, restart, create_shortcut, not_implemented, update

--- a/fishy/helper/__init__.py
+++ b/fishy/helper/__init__.py
@@ -1,4 +1,4 @@
-from .auto_update import auto_upgrade
+from .auto_update import auto_upgrade, upgrade_avail, versions
 from .config import Config
 from .helper import open_web, initialize_uid, install_thread_excepthook, unhandled_exception_logging, manifest_file, \
     create_shortcut_first, check_addon, restart, create_shortcut, not_implemented

--- a/fishy/helper/auto_update.py
+++ b/fishy/helper/auto_update.py
@@ -96,4 +96,4 @@ def auto_upgrade():
     version = _hr_version(_get_highest_version(index, pkg))
     logging.info(f"Updating to v{version}, Please Wait...")
     subprocess.call(["python", '-m', 'pip', 'install', '--upgrade', 'fishy', '--user'])
-    execl(sys.executable, *([sys.executable] + sys.argv))
+    execl(sys.executable, *([sys.executable, '-m', 'fishy'] + sys.argv[1:]))

--- a/fishy/helper/auto_update.py
+++ b/fishy/helper/auto_update.py
@@ -11,6 +11,10 @@ from os import execl
 
 from bs4 import BeautifulSoup
 
+def _hr_version(v):
+    return '.'.join([str(x) for x in v])
+    #return str(v[0])+"."+str(v[1])+"."+str(v[2])
+
 
 def _normalize_version(v):
     """
@@ -68,17 +72,28 @@ def _get_current_version():
     return _normalize_version(fishy.__version__)
 
 
+index = "https://pypi.python.org/simple"
+pkg = "fishy"
+
+def versions():
+    return _hr_version(_get_current_version()), _hr_version(_get_highest_version(index, pkg))
+
+
+def upgrade_avail():
+    """
+    Checks if update is available
+    :return: boolean
+    """
+    return _get_current_version() < _get_highest_version(index, pkg)
+
+
 def auto_upgrade():
     """
     public function,
     compares current version with the latest version (from web),
     if current version is older, then it updates and restarts the script
     """
-    index = "https://pypi.python.org/simple"
-    pkg = "fishy"
-    hightest_version = _get_highest_version(index, pkg)
-    if hightest_version > _get_current_version():
-        version = '.'.join([str(x) for x in hightest_version])
-        logging.info(f"Updating to v{version}, Please Wait...")
-        subprocess.call(["python", '-m', 'pip', 'install', '--upgrade', 'fishy', '--user'])
-        execl(sys.executable, *([sys.executable] + sys.argv))
+    version = _hr_version(_get_highest_version(index, pkg))
+    logging.info(f"Updating to v{version}, Please Wait...")
+    subprocess.call(["python", '-m', 'pip', 'install', '--upgrade', 'fishy', '--user'])
+    execl(sys.executable, *([sys.executable] + sys.argv))

--- a/fishy/helper/config.py
+++ b/fishy/helper/config.py
@@ -53,8 +53,12 @@ class Config:
         deletes a key from config
         :param key: key to delete
         """
-        del self.config_dict[key]
-        self.save_config()
+        try:
+            del self.config_dict[key]
+            self.save_config()
+        except KeyError:
+            pass
+
 
     def save_config(self):
         """

--- a/fishy/helper/helper.py
+++ b/fishy/helper/helper.py
@@ -76,7 +76,6 @@ def install_thread_excepthook():
     If using psyco, call psycho.cannotcompile(threading.Thread.run)
     since this replaces a new-style class method.
     """
-    import sys
     run_old = threading.Thread.run
 
     # noinspection PyBroadException
@@ -168,3 +167,10 @@ def get_documents():
 
 def restart():
     os.execl(sys.executable, *([sys.executable] + sys.argv))
+
+
+def update():
+    from .config import config
+
+    config.delete("dont_ask_update")
+    restart()


### PR DESCRIPTION
This PR adds a dialog popup before update is executed.
That way users take their own responsibility to upgrade and gain the ability to downgrade fishy as they like.

It also employs a saved config variable to **not ask again**, as well as a filemenu entry to update if that variable is set.