### PR TITLE
update uid on discord login, and fetch uid from config (never cache it) (0.4.4)

### DIFF
--- a/fishy/engine/semifisher/fishing_event.py
+++ b/fishy/engine/semifisher/fishing_event.py
@@ -33,7 +33,6 @@ class FishEvent:
     # initialize these
     action_key = 'e'
     collect_allow_auto = False
-    uid = None
     sound = False
 
 
@@ -117,7 +116,7 @@ def on_look():
 
 def on_idle():
     if FishEvent.fishCaught > 0:
-        web.send_hole_deplete(FishEvent.uid, FishEvent.fishCaught, time.time() - FishEvent.hole_start_time,
+        web.send_hole_deplete(FishEvent.fishCaught, time.time() - FishEvent.hole_start_time,
                               FishEvent.fish_times)
         FishEvent.fishCaught = 0
 

--- a/fishy/gui/config_top.py
+++ b/fishy/gui/config_top.py
@@ -59,10 +59,10 @@ def start_semifisher_config(gui: 'GUI'):
 
     def toggle_sub():
         if web.is_subbed(config.get("uid"))[0]:
-            if web.unsub(config.get("uid")):
+            if web.unsub():
                 gui._notify.set(0)
         else:
-            if web.sub(config.get("uid")):
+            if web.sub():
                 gui._notify.set(1)
 
     def toggle_collect():
@@ -83,7 +83,7 @@ def start_semifisher_config(gui: 'GUI'):
     gui._notify_check = Checkbutton(controls_frame, command=toggle_sub, variable=gui._notify)
     gui._notify_check.grid(row=0, column=1)
     gui._notify_check['state'] = DISABLED
-    is_subbed = web.is_subbed(config.get('uid'))
+    is_subbed = web.is_subbed()
     if is_subbed[1]:
         gui._notify_check['state'] = NORMAL
         gui._notify.set(is_subbed[0])

--- a/fishy/gui/discord_login.py
+++ b/fishy/gui/discord_login.py
@@ -18,8 +18,8 @@ if typing.TYPE_CHECKING:
 
 # noinspection PyProtectedMember
 def discord_login(gui: 'GUI'):
-    if web.is_logged_in(config.get("uid")):
-        if web.logout(config.get("uid")):
+    if web.is_logged_in():
+        if web.logout():
             gui.login.set(0)
         return
 

--- a/fishy/gui/main_gui.py
+++ b/fishy/gui/main_gui.py
@@ -39,7 +39,7 @@ def _create(gui: 'GUI'):
 
     filemenu = Menu(menubar, tearoff=0)
 
-    login = web.is_logged_in(config.get('uid'))
+    login = web.is_logged_in()
     gui.login = IntVar()
     gui.login.set(1 if login > 0 else 0)
     state = DISABLED if login == -1 else ACTIVE

--- a/fishy/web/web.py
+++ b/fishy/web/web.py
@@ -11,11 +11,11 @@ _session_id = None
 
 
 @fallback(-1)
-def is_logged_in(uid):
-    if uid is None:
+def is_logged_in():
+    if config.get("uid") is None:
         return -1
 
-    body = {"uid": uid}
+    body = {"uid": config.get("uid")}
     response = requests.get(urls.discord, params=body)
     logged_in = response.json()["discord_login"]
     return 1 if logged_in else 0
@@ -29,13 +29,17 @@ def login(uid, login_code):
     }
     reponse = requests.post(urls.discord, json=body)
     result = reponse.json()
+
+    if "new_id" in result:
+        config.set("uid", result["new_id"])
+
     return result["success"]
 
 
 @fallback(False)
-def logout(uid):
+def logout():
     body = {
-        "uid": uid,
+        "uid": config.get("uid"),
     }
     reponse = requests.delete(urls.discord, json=body)
     result = reponse.json()
@@ -43,15 +47,16 @@ def logout(uid):
 
 
 @fallback(False)
-def register_user(uid):
+def register_user(new_uid):
     ip = get_ip(GoogleDnsProvider)
-    body = {"uid": uid, "ip": ip}
+    body = {"uid": new_uid, "ip": ip}
     response = requests.post(urls.user, json=body)
     return response.ok and response.json()["success"]
 
 
 @fallback(None)
 def send_notification(uid, message):
+    # todo clean dead code
     if not is_subbed(uid):
         return False
 
@@ -61,38 +66,38 @@ def send_notification(uid, message):
 
 @uses_session
 @fallback(None)
-def send_hole_deplete(uid, fish_caught, hole_time, fish_times):
+def send_hole_deplete(fish_caught, hole_time, fish_times):
     hole_data = {
         "fish_caught": fish_caught,
         "hole_time": hole_time,
         "fish_times": fish_times,
-        "session": get_session(uid)
+        "session": get_session()
     }
 
-    body = {"uid": uid, "hole_data": hole_data}
+    body = {"uid": config.get("uid"), "hole_data": hole_data}
     requests.post(urls.hole_depleted, json=body)
 
 
 @fallback(False)
-def sub(uid):
-    body = {"uid": uid}
+def sub():
+    body = {"uid": config.get("uid")}
     response = requests.post(urls.subscription, json=body)
     result = response.json()
     return result["success"]
 
 
 @fallback((False, False))
-def is_subbed(uid):
+def is_subbed():
     """
     :param uid:
     :param lazy:
     :return: Tuple[is_subbed, success]
     """
 
-    if uid is None:
+    if config.get("uid") is None:
         return False, False
 
-    body = {"uid": uid}
+    body = {"uid": config.get("uid")}
     response = requests.get(urls.subscription, params=body)
 
     if response.status_code != 200:
@@ -103,8 +108,8 @@ def is_subbed(uid):
 
 
 @fallback(None)
-def unsub(uid):
-    body = {"uid": uid}
+def unsub():
+    body = {"uid": config.get("uid")}
     response = requests.delete(urls.subscription, json=body)
     result = response.json()
     return result["success"]


### PR DESCRIPTION
currently (on live v0.4.3) on discord login, user's discord id is just added to the user's database. When the user creates another fishy account (by deleting the config file) and they login again using discord. Their discord id then corresponds to multiple fishy uid, which becomes a problem when checking for beta access

Backend has been reworked to merge these two different user accounts, and send back the old uid to be updated in the frontend. **This PR uses that old uid sent by the backend and updates it in the config.** 

Also, in some places uid is cached which might cause a problem if uid is updated from config in runtime. So now, uid will aways be pulled from the config whenever it is needed.