### PR TITLE
Remove didnt start popup (0.4.5)

### DIFF
--- a/fishy/engine/semifisher/engine.py
+++ b/fishy/engine/semifisher/engine.py
@@ -59,8 +59,7 @@ class SemiFisherEngine(IEngine):
     def _wait_and_check(self):
         time.sleep(10)
         if not FishEvent.FishingStarted and self.start:
-            self.gui.show_error("Doesn't look like fishing has started\n\n"
-                                "Check out #read-me-first on our discord channel to troubleshoot the issue")
+            logging.warn("Doesn't look like fishing has started \nCheck out #read-me-first on our discord channel to troubleshoot the issue")
 
     def show_pixel_vals(self):
         def show():


### PR DESCRIPTION
This PR swaps the popup call with a call to `logging.warn`. This will stop the annoying popup and preserve the information.