### PR TITLE
let server create uid instead of client, keeping session creating code on oneside

### DIFF
--- a/fishy/constants.py
+++ b/fishy/constants.py
@@ -1,3 +1,3 @@
-apiversion = 1
+apiversion = 2
 chalutier = ("Chalutier", "https://www.esoui.com/downloads/dl2934/1616505502-Chalutier_1.1.1.zip", 111)
 lam2 = ("LibAddonMenu-2.0", "https://www.esoui.com/downloads/dl7/LibAddonMenu-2.0r32.zip", 32)

--- a/fishy/helper/helper.py
+++ b/fishy/helper/helper.py
@@ -56,8 +56,8 @@ def initialize_uid():
     if config.get("uid") is not None:
         return
 
-    new_uid = _create_new_uid()
-    if web.register_user(new_uid):
+    new_uid = web.register_user()
+    if new_uid is not None:
         config.set("uid", new_uid)
     else:
         logging.error("Couldn't register uid, some features might not work")

--- a/fishy/web/web.py
+++ b/fishy/web/web.py
@@ -42,12 +42,13 @@ def logout():
     return result["success"]
 
 
-@fallback(False)
-def register_user(new_uid):
+@fallback(None)
+def register_user():
     ip = get_ip(GoogleDnsProvider)
-    body = {"uid": new_uid, "ip": ip, "apiversion":apiversion}
+    body = {"ip": ip, "apiversion": apiversion}
     response = requests.post(urls.user, json=body)
-    return response.ok and response.json()["success"]
+    result = response.json()
+    return result["uid"]
 
 
 @fallback(None)


### PR DESCRIPTION
Currently, client creates uid and backend creates session uid.... both the methods of creating uid is the same.... so this PR intends to keep both the creation on backend instead of keeping in different projects

corresponding PR on backend: https://github.com/fishyboteso/fishy-web/pull/4