### PR TITLE
change color of dead-state according to chalutier 1.1.3

### DIFF
--- a/fishy/engine/semifisher/fishing_mode.py
+++ b/fishy/engine/semifisher/fishing_mode.py
@@ -15,7 +15,7 @@ class State(Enum):
     LOOT     = [  0, 255, 204]
     INVFULL  = [  0, 255,  51]
     FIGHT    = [120, 255, 204]
-    DEAD     = [  0,   0,   0]
+    DEAD     = [  0,   0,  51]
 
 def _notify(event):
     for subscriber in subscribers:


### PR DESCRIPTION
This PR just changes the default color according to the change in chalutier 1.1.3. This is to avoid triggering dead state with the loading screen.
see https://github.com/fishyboteso/Chalutier/commit/4dda33f043a6021817e4c91900aa98197b913ed7