### PR TITLE
remove sleep before fishing, with bugfix in chalutier 1.1.3

### DIFF
--- a/fishy/engine/semifisher/fishing_mode.py
+++ b/fishy/engine/semifisher/fishing_mode.py
@@ -39,10 +39,7 @@ def loop(hsv):
         if all(hsv == s.value):
             FishingMode.CurrentMode = s
 
-    if FishingMode.CurrentMode == State.LOOKING:
-        _notify(FishingMode.CurrentMode)
-        time.sleep(1)
-    elif FishingMode.CurrentMode != FishingMode.PrevMode:
+    if FishingMode.CurrentMode != FishingMode.PrevMode:
         _notify(FishingMode.CurrentMode)
 
     FishingMode.PrevMode = FishingMode.CurrentMode


### PR DESCRIPTION
With a bugfix in chalutier 1.1.3, it is now possible to not sleep before fishing.
Before chalutier 1.1.3 fishing started to fast and got locked. This happened because subscribed functions are only notified on fishing mode changes. For that reason sleep was used as a workaround to avoid that lock.

With Chalutier 1.1.3 "loot" state is now set/unset on SCENE_SHOWN and SCENE_HIDDEN of the ingame loot scene, instead of SCENE_SHOWING and SCENE_HIDING states. The latter changed the Chalutier state to fast, thus fishy started fishing to early.
Instead changing from "loot" to "looking" on SCENE_HIDDEN does allow to start fishing with the first frame of "looking".

See: https://github.com/fishyboteso/Chalutier/commit/20cda1a3f0024135fd45c0b5b3fa490baf4d3e88