### PR TITLE
remove uninstallation of old addons

### DIFF
--- a/fishy/__main__.py
+++ b/fishy/__main__.py
@@ -62,8 +62,6 @@ def initialize(window_to_hide):
     if not config.get("addoninstalled", 0) or helper.get_addonversion(chalutier[0]) < chalutier[2]:
         helper.install_addon(*chalutier)
         helper.install_addon(*lam2)
-        helper.remove_addon("ProvisionsChalutier") #TODO delete with fishy 0.4.6
-        helper.remove_addon("FooAddon") #TODO delete with fishy 0.4.6
     config.set("addoninstalled", helper.get_addonversion(chalutier[0]))
 
 


### PR DESCRIPTION
This PR removes the uninstallation of ProvisionsChalutier and FooAddon from the code. This was a necessary change from 0.4.4 to 0.4.5
With new fishy users (from 0.4.5 on) this is not needed anymore. For old users this affected the freedom of addon choice/naming negatively.