### PR TITLE
remove label from fishingmode for logging

### DIFF
--- a/fishy/engine/semifisher/engine.py
+++ b/fishy/engine/semifisher/engine.py
@@ -67,7 +67,7 @@ class SemiFisherEngine(IEngine):
             t = 0
             while t < 10.0:
                 t += freq
-                logging.debug(str(FishingMode.CurrentMode.label) + ":" + str(self.fishPixWindow.get_capture()[0][0]))
+                logging.debug(str(FishingMode.CurrentMode) + ":" + str(self.fishPixWindow.get_capture()[0][0]))
                 time.sleep(freq)
 
         logging.debug("Will display pixel values for 10 seconds")


### PR DESCRIPTION
This PR removes the label reference from FishingMode.CurrentMode, this was overlooked with update 0.4.5.

"Debug > Checkpixel Value" throws following error:
`Traceback (most recent call last):`
`File "C:\Users\coma\AppData\Local\Programs\Python\Python37\lib\threading.py", line 917, in _bootstrap_inner`
`self.run()`
`File "C:\Users\coma\AppData\Local\Programs\Python\Python37\lib\threading.py", line 865, in run`
`self._target(*self._args, **self._kwargs)`
`File "C:\Users\coma\AppData\Roaming\Python\Python37\site-packages\fishy\engine\semifisher\engine.py", line 70, in show`
`logging.debug(str(FishingMode.CurrentMode.label) + ":" + str(self.fishPixWindow.get_capture()[0][0]))`
`AttributeError: 'State' object has no attribute 'label'`