### PR TITLE
Set auto_collect always enabled

### DIFF
--- a/fishy/engine/semifisher/fishing_event.py
+++ b/fishy/engine/semifisher/fishing_event.py
@@ -33,7 +33,6 @@ class FishEvent:
     # initialize these
     action_key = 'e'
     collect_key = 'r' 
-    collect_allow_auto = False
     sound = False
 
 
@@ -59,7 +58,6 @@ def init():
     FishEvent.jitter = config.get("jitter", False)
     FishEvent.action_key = config.get("action_key", 'e')
     FishEvent.collect_key = config.get("collect_key", 'r')
-    FishEvent.collect_allow_auto = config.get("collect_allow_auto", False)
     FishEvent.uid = config.get("uid")
     FishEvent.sound = config.get("sound_notification", False)
 
@@ -161,10 +159,9 @@ def on_reelin():
 
 
 def on_loot():
-    if FishEvent.collect_allow_auto:
-        _fishing_sleep(0.15)
-        keyboard.press_and_release(FishEvent.collect_key)
-        _fishing_sleep(0.3)
+    _fishing_sleep(0)
+    keyboard.press_and_release(FishEvent.collect_key)
+    _fishing_sleep(0)
 
 
 def on_invfull():

--- a/fishy/gui/config_top.py
+++ b/fishy/gui/config_top.py
@@ -51,7 +51,6 @@ def start_semifisher_config(gui: 'GUI'):
     def save():
         gui.config.set("action_key", action_key_entry.get(), False)
         gui.config.set("collect_key", collect_key_entry.get(), False)
-        gui.config.set("collect_allow_auto", collect_allow_auto.instate(['selected']), False)
         gui.config.set("borderless", borderless.instate(['selected']), False)
         gui.config.set("jitter", jitter.instate(['selected']), False)
         gui.config.set("sound_notification", sound.instate(['selected']), False)
@@ -64,10 +63,6 @@ def start_semifisher_config(gui: 'GUI'):
         else:
             if web.sub():
                 gui._notify.set(1)
-
-    def toggle_collect():
-        gui.config.set("collect_allow_auto", collect_allow_auto.instate(['selected']), False)
-        collect_key_entry['state'] = NORMAL if config.get("collect_allow_auto") else DISABLED
 
     def del_entry_key(event):
         event.widget.delete(0,"end")
@@ -98,15 +93,10 @@ def start_semifisher_config(gui: 'GUI'):
     action_key_entry.insert(0, config.get("action_key", "e"))
     action_key_entry.bind("<KeyRelease>", del_entry_key)
 
-    Label(controls_frame, text="Auto-Looting: ").grid(row=3, column=0, pady=(15, 0))
-    collect_allow_auto = Checkbutton(controls_frame, command=toggle_collect, var=BooleanVar(value=config.get("collect_allow_auto")))
-    collect_allow_auto.grid(row=3, column=1, pady=(15, 0))
-
-    Label(controls_frame, text="Looting Key:").grid(row=4, column=0, pady=(0, 15))
+    Label(controls_frame, text="Looting Key:").grid(row=4, column=0, pady=(5, 5))
     collect_key_entry = Entry(controls_frame, justify=CENTER)
-    collect_key_entry.grid(row=4, column=1, pady=(0, 15))
+    collect_key_entry.grid(row=4, column=1, pady=(5, 5))
     collect_key_entry.insert(0, config.get("collect_key", "r"))
-    collect_key_entry['state'] = NORMAL if config.get("collect_allow_auto") else DISABLED
     collect_key_entry.bind("<KeyRelease>", del_entry_key)
 
     Label(controls_frame, text="Sound Notification: ").grid(row=5, column=0, pady=(5, 5))


### PR DESCRIPTION
With fishy 0.4.5 the state machine went from fishy to chalutier addon.
Since then it was possible to detect the loot scene on demand. Consequently there is no need to enable auto-looting within fishy.
Thus all traces of collect_allow_auto and all connected functions are removed with this PR.

Also with Chalutier 1.1.3 there is no need to wait a certain time before looting/fishing again. For that reason the delays in on_loot are  removed as well.
See https://github.com/fishyboteso/Chalutier/commit/20cda1a3f0024135fd45c0b5b3fa490baf4d3e88