### PR TITLE
Add a 100ms sleep to semifisher loop

### DIFF
--- a/fishy/engine/semifisher/engine.py
+++ b/fishy/engine/semifisher/engine.py
@@ -51,6 +51,7 @@ class SemiFisherEngine(IEngine):
 
             self.fishPixWindow.crop = PixelLoc.val
             fishing_mode.loop(capture[0][0])
+            time.sleep(0.1)
 
         logging.info("Fishing engine stopped")
         self.gui.bot_started(False)


### PR DESCRIPTION
While the main monitor loop runs we are constantly rechecking, which drives a lot of CPU usage.
By sleeping for 100ms we can significantly reduce this without significantly impacting the bot.