### PR TITLE
Cleanup Imports with flake8 and isort

### DIFF
--- a/fishy/__main__.py
+++ b/fishy/__main__.py
@@ -3,16 +3,17 @@ import logging
 import os
 import sys
 import traceback
+
 import win32con
 import win32gui
 
 import fishy
-from fishy import web, helper, gui
+from fishy import gui, helper, web
+from fishy.constants import chalutier, lam2
 from fishy.engine.common.event_handler import EngineEventHandler
 from fishy.gui import GUI, splash, update_dialog
 from fishy.helper import hotkey
 from fishy.helper.config import config
-from fishy.constants import chalutier, lam2
 
 
 def check_window_name(title):

--- a/fishy/engine/common/window.py
+++ b/fishy/engine/common/window.py
@@ -5,7 +5,7 @@ import cv2
 import imutils
 
 from fishy.engine.common import window_server
-from fishy.engine.common.window_server import WindowServer, Status
+from fishy.engine.common.window_server import Status, WindowServer
 from fishy.helper import helper
 
 

--- a/fishy/engine/common/window_server.py
+++ b/fishy/engine/common/window_server.py
@@ -1,16 +1,14 @@
 import logging
+import math
 from enum import Enum
 from threading import Thread
 
 import cv2
-import math
-
+import numpy as np
 import pywintypes
 import win32gui
-from win32api import GetSystemMetrics
-
-import numpy as np
 from PIL import ImageGrab
+from win32api import GetSystemMetrics
 
 from fishy.helper.config import config
 

--- a/fishy/engine/fullautofisher/calibrator.py
+++ b/fishy/engine/fullautofisher/calibrator.py
@@ -1,13 +1,12 @@
-import math
 import logging
+import math
 import time
 
 import cv2
 import numpy as np
-
-from fishy.engine.fullautofisher.engine import FullAuto
 from pynput import keyboard, mouse
 
+from fishy.engine.fullautofisher.engine import FullAuto
 from fishy.helper.config import config
 
 mse = mouse.Controller()

--- a/fishy/engine/fullautofisher/controls.py
+++ b/fishy/engine/fullautofisher/controls.py
@@ -1,14 +1,13 @@
 import logging
 
-from fishy.helper import hotkey
-
 from fishy.engine.fullautofisher.engine import FullAuto, State
+from fishy.helper import hotkey
 from fishy.helper.hotkey import Key
 
 
 def get_controls(engine: FullAuto):
-    from fishy.engine.fullautofisher.recorder import Recorder
     from fishy.engine.fullautofisher.player import Player
+    from fishy.engine.fullautofisher.recorder import Recorder
     controls = [
         ("MODE_SELECT", {
             Key.RIGHT: (Recorder(engine).toggle_recording, "start/stop record"),

--- a/fishy/engine/fullautofisher/engine.py
+++ b/fishy/engine/fullautofisher/engine.py
@@ -1,24 +1,22 @@
+import logging
 import math
+import time
 import traceback
 from enum import Enum
 from threading import Thread
 
 import cv2
-import logging
-import time
-
-from fishy.constants import libgps, fishyqr, lam2
-from fishy.engine.fullautofisher.qr_detection import get_values_from_image, get_qr_location
-from fishy.engine.semifisher.fishing_mode import FishingMode
-
-from fishy.engine import SemiFisherEngine
-from fishy.engine.common.window import WindowClient
-from fishy.engine.semifisher import fishing_mode, fishing_event
-
-from fishy.engine.common.IEngine import IEngine
 from pynput import keyboard, mouse
 
-from fishy.helper import hotkey, helper
+from fishy.constants import fishyqr, lam2, libgps
+from fishy.engine import SemiFisherEngine
+from fishy.engine.common.IEngine import IEngine
+from fishy.engine.common.window import WindowClient
+from fishy.engine.fullautofisher.qr_detection import (get_qr_location,
+                                                      get_values_from_image)
+from fishy.engine.semifisher import fishing_event, fishing_mode
+from fishy.engine.semifisher.fishing_mode import FishingMode
+from fishy.helper import helper, hotkey
 from fishy.helper.helper import sign
 
 mse = mouse.Controller()
@@ -46,9 +44,9 @@ class FullAuto(IEngine):
     state = State.NONE
 
     def __init__(self, gui_ref):
-        from fishy.engine.fullautofisher.controls import Controls
         from fishy.engine.fullautofisher import controls
         from fishy.engine.fullautofisher.calibrator import Calibrator
+        from fishy.engine.fullautofisher.controls import Controls
         from fishy.engine.fullautofisher.test import Test
 
         super().__init__(gui_ref)

--- a/fishy/engine/fullautofisher/player.py
+++ b/fishy/engine/fullautofisher/player.py
@@ -2,10 +2,8 @@ import logging
 import pickle
 from pprint import pprint
 
-from fishy.engine.semifisher import fishing_event, fishing_mode
-
 from fishy.engine.fullautofisher.engine import FullAuto, State
-
+from fishy.engine.semifisher import fishing_event, fishing_mode
 from fishy.helper import helper
 from fishy.helper.config import config
 

--- a/fishy/engine/fullautofisher/qr_detection.py
+++ b/fishy/engine/fullautofisher/qr_detection.py
@@ -3,11 +3,10 @@ import os
 from datetime import datetime
 
 import cv2
-
-from fishy.helper.helper import get_documents
-
 import numpy as np
 from pyzbar.pyzbar import decode
+
+from fishy.helper.helper import get_documents
 
 
 def get_qr_location(og_img):

--- a/fishy/engine/fullautofisher/recorder.py
+++ b/fishy/engine/fullautofisher/recorder.py
@@ -5,7 +5,6 @@ from pprint import pprint
 from tkinter.filedialog import asksaveasfile
 
 from fishy.engine.fullautofisher.engine import FullAuto, State
-
 from fishy.helper.hotkey import Key
 from fishy.helper.hotkey_process import HotKey
 

--- a/fishy/engine/semifisher/engine.py
+++ b/fishy/engine/semifisher/engine.py
@@ -1,20 +1,18 @@
+import logging
 import time
 import typing
-import logging
 from threading import Thread
-from typing import Callable
-from typing import Optional
+from typing import Callable, Optional
+
 from playsound import playsound
 
-from fishy.engine.common.window import WindowClient
-from fishy.engine.semifisher.fishing_mode import Colors, FishingMode
-
 from fishy.engine.common.IEngine import IEngine
+from fishy.engine.common.window import WindowClient
+from fishy.engine.semifisher import fishing_event, fishing_mode
 from fishy.engine.semifisher.fishing_event import FishEvent
-from fishy.engine.semifisher import fishing_mode, fishing_event
+from fishy.engine.semifisher.fishing_mode import Colors, FishingMode
 from fishy.engine.semifisher.pixel_loc import PixelLoc
 from fishy.helper import helper
-
 from fishy.helper.luaparser import sv_color_extract
 
 if typing.TYPE_CHECKING:

--- a/fishy/engine/semifisher/engine.py
+++ b/fishy/engine/semifisher/engine.py
@@ -1,6 +1,5 @@
 import time
 import typing
-import cv2
 import logging
 from threading import Thread
 from typing import Callable
@@ -11,7 +10,6 @@ from fishy.engine.common.window import WindowClient
 from fishy.engine.semifisher.fishing_mode import Colors, FishingMode
 
 from fishy.engine.common.IEngine import IEngine
-from fishy.engine.semifisher.fishing_mode import FishingMode
 from fishy.engine.semifisher.fishing_event import FishEvent
 from fishy.engine.semifisher import fishing_mode, fishing_event
 from fishy.engine.semifisher.pixel_loc import PixelLoc

--- a/fishy/engine/semifisher/fishing_event.py
+++ b/fishy/engine/semifisher/fishing_event.py
@@ -4,15 +4,16 @@ Defines different fishing modes (states) which acts as state for state machine
 also implements callbacks which is called when states are changed
 """
 import logging
-import time
 import random
+import time
+
 import keyboard
 from playsound import playsound
-from win32gui import GetWindowText, GetForegroundWindow
+from win32gui import GetForegroundWindow, GetWindowText
 
 from fishy import web
 from fishy.engine.semifisher import fishing_mode
-from fishy.engine.semifisher.fishing_mode import State, FishingMode
+from fishy.engine.semifisher.fishing_mode import FishingMode, State
 from fishy.helper import helper
 from fishy.helper.config import config
 

--- a/fishy/engine/semifisher/fishing_mode.py
+++ b/fishy/engine/semifisher/fishing_mode.py
@@ -1,4 +1,3 @@
-import time
 from enum import Enum
 
 subscribers = []

--- a/fishy/gui/config_top.py
+++ b/fishy/gui/config_top.py
@@ -1,15 +1,12 @@
 import logging
 import os
+import tkinter as tk
+import tkinter.ttk as ttk
 import typing
 from tkinter.filedialog import askopenfilename
 
-from fishy.helper import helper
-
 from fishy import web
-
-import tkinter as tk
-import tkinter.ttk as ttk
-
+from fishy.helper import helper
 from fishy.helper.config import config
 from fishy.helper.popup import PopUp
 

--- a/fishy/gui/config_top.py
+++ b/fishy/gui/config_top.py
@@ -7,8 +7,8 @@ from fishy.helper import helper
 
 from fishy import web
 
-from tkinter import *
-from tkinter.ttk import *
+import tkinter as tk
+import tkinter.ttk as ttk
 
 from fishy.helper.config import config
 from fishy.helper.popup import PopUp
@@ -19,7 +19,7 @@ if typing.TYPE_CHECKING:
 
 def start_fullfisher_config(gui: 'GUI'):
     top = PopUp(helper.empty_function, gui._root, background=gui._root["background"])
-    controls_frame = Frame(top)
+    controls_frame = ttk.Frame(top)
     top.title("Config")
 
     def file_name():
@@ -38,10 +38,10 @@ def start_fullfisher_config(gui: 'GUI'):
 
         file_name_label.set(file_name())
 
-    file_name_label = StringVar(value=file_name())
-    Label(controls_frame, textvariable=file_name_label).grid(row=0, column=0)
-    Button(controls_frame, text="Select fishy file", command=select_file).grid(row=0, column=1)
-    Label(controls_frame, text="Use semi-fisher config for rest").grid(row=2, column=0, columnspan=2)
+    file_name_label = tk.StringVar(value=file_name())
+    ttk.Label(controls_frame, textvariable=file_name_label).grid(row=0, column=0)
+    ttk.Button(controls_frame, text="Select fishy file", command=select_file).grid(row=0, column=1)
+    ttk.Label(controls_frame, text="Use semi-fisher config for rest").grid(row=2, column=0, columnspan=2)
 
     controls_frame.pack(padx=(5, 5), pady=(5, 5))
     top.start()
@@ -69,42 +69,42 @@ def start_semifisher_config(gui: 'GUI'):
         event.widget.insert(0, str(event.char))
 
     top = PopUp(save, gui._root, background=gui._root["background"])
-    controls_frame = Frame(top)
+    controls_frame = ttk.Frame(top)
     top.title("Config")
 
-    Label(controls_frame, text="Notification:").grid(row=0, column=0)
+    ttk.Label(controls_frame, text="Notification:").grid(row=0, column=0)
 
-    gui._notify = IntVar(0)
-    gui._notify_check = Checkbutton(controls_frame, command=toggle_sub, variable=gui._notify)
+    gui._notify = tk.IntVar(0)
+    gui._notify_check = ttk.Checkbutton(controls_frame, command=toggle_sub, variable=gui._notify)
     gui._notify_check.grid(row=0, column=1)
-    gui._notify_check['state'] = DISABLED
+    gui._notify_check['state'] = tk.DISABLED
     is_subbed = web.is_subbed()
     if is_subbed[1]:
-        gui._notify_check['state'] = NORMAL
+        gui._notify_check['state'] = tk.NORMAL
         gui._notify.set(is_subbed[0])
 
-    Label(controls_frame, text="Fullscreen: ").grid(row=1, column=0, pady=(5, 5))
-    borderless = Checkbutton(controls_frame, var=BooleanVar(value=config.get("borderless")))
+    ttk.Label(controls_frame, text="Fullscreen: ").grid(row=1, column=0, pady=(5, 5))
+    borderless = ttk.Checkbutton(controls_frame, var=tk.BooleanVar(value=config.get("borderless")))
     borderless.grid(row=1, column=1)
 
-    Label(controls_frame, text="Action Key:").grid(row=2, column=0)
-    action_key_entry = Entry(controls_frame, justify=CENTER)
+    ttk.Label(controls_frame, text="Action Key:").grid(row=2, column=0)
+    action_key_entry = ttk.Entry(controls_frame, justify=tk.CENTER)
     action_key_entry.grid(row=2, column=1)
     action_key_entry.insert(0, config.get("action_key", "e"))
     action_key_entry.bind("<KeyRelease>", del_entry_key)
 
-    Label(controls_frame, text="Looting Key:").grid(row=4, column=0, pady=(5, 5))
-    collect_key_entry = Entry(controls_frame, justify=CENTER)
+    ttk.Label(controls_frame, text="Looting Key:").grid(row=4, column=0, pady=(5, 5))
+    collect_key_entry = ttk.Entry(controls_frame, justify=tk.CENTER)
     collect_key_entry.grid(row=4, column=1, pady=(5, 5))
     collect_key_entry.insert(0, config.get("collect_key", "r"))
     collect_key_entry.bind("<KeyRelease>", del_entry_key)
 
-    Label(controls_frame, text="Sound Notification: ").grid(row=5, column=0, pady=(5, 5))
-    sound = Checkbutton(controls_frame, var=BooleanVar(value=config.get("sound_notification")))
+    ttk.Label(controls_frame, text="Sound Notification: ").grid(row=5, column=0, pady=(5, 5))
+    sound = ttk.Checkbutton(controls_frame, var=tk.BooleanVar(value=config.get("sound_notification")))
     sound.grid(row=5, column=1)
 
-    Label(controls_frame, text="Human-Like Delay: ").grid(row=6, column=0, pady=(5, 5))
-    jitter = Checkbutton(controls_frame, var=BooleanVar(value=config.get("jitter")))
+    ttk.Label(controls_frame, text="Human-Like Delay: ").grid(row=6, column=0, pady=(5, 5))
+    jitter = ttk.Checkbutton(controls_frame, var=tk.BooleanVar(value=config.get("jitter")))
     jitter.grid(row=6, column=1)
 
     controls_frame.pack(padx=(5, 5), pady=(5, 5))

--- a/fishy/gui/discord_login.py
+++ b/fishy/gui/discord_login.py
@@ -1,12 +1,11 @@
 import time
 import tkinter as tk
 import tkinter.ttk as ttk
-
 import typing
 
+from fishy.libs.tkhtmlview import HTMLLabel
 from fishy.web import web
 
-from fishy.libs.tkhtmlview import HTMLLabel
 from ..helper.config import config
 
 if typing.TYPE_CHECKING:

--- a/fishy/gui/discord_login.py
+++ b/fishy/gui/discord_login.py
@@ -4,8 +4,6 @@ import tkinter.ttk as ttk
 
 import typing
 
-from fishy.helper import helper
-
 from fishy.web import web
 
 from fishy.libs.tkhtmlview import HTMLLabel

--- a/fishy/gui/discord_login.py
+++ b/fishy/gui/discord_login.py
@@ -1,7 +1,6 @@
 import time
-from tkinter import *
-from tkinter import messagebox
-from tkinter.ttk import *
+import tkinter as tk
+import tkinter.ttk as ttk
 
 import typing
 
@@ -34,14 +33,14 @@ def discord_login(gui: 'GUI'):
         code = int(login_code.get()) if login_code.get().isdigit() else 0
         if web.login(config.get("uid"), code):
             gui.login.set(1)
-            messagebox.showinfo("Note!", "Logged in successfuly!")
+            tk.messagebox.showinfo("Note!", "Login successful!")
             quit_top()
         else:
-            messagebox.showerror("Error", "Logged wasn't successful")
+            tk.messagebox.showerror("Error", "Login was not successful!")
 
     top_running = [True]
 
-    top = Toplevel(background=gui._root["background"])
+    top = tk.Toplevel(background=gui._root["background"])
     top.minsize(width=300, height=300)
     top.title("Notification Setup")
 
@@ -58,8 +57,8 @@ def discord_login(gui: 'GUI'):
     html_label.pack(pady=(20, 5))
     html_label.fit_height()
 
-    login_code = Entry(top, justify=CENTER, font="Calibri 15")
-    login_code.pack(padx=(15, 15), expand=True, fill=BOTH)
+    login_code = ttk.Entry(top, justify=tk.CENTER, font="Calibri 15")
+    login_code.pack(padx=(15, 15), expand=True, fill=tk.BOTH)
 
     html_label = HTMLLabel(top,
                            html=f'<div style="color: {gui._console["fg"]}; text-align: center">'
@@ -69,7 +68,7 @@ def discord_login(gui: 'GUI'):
     html_label.pack(pady=(5, 5))
     html_label.fit_height()
 
-    Button(top, text="REGISTER", command=check).pack(pady=(5, 20))
+    ttk.Button(top, text="REGISTER", command=check).pack(pady=(5, 20))
 
     top.protocol("WM_DELETE_WINDOW", quit_top)
     top.grab_set()

--- a/fishy/gui/funcs.py
+++ b/fishy/gui/funcs.py
@@ -1,6 +1,5 @@
-from tkinter import messagebox
-
 import typing
+from tkinter import messagebox
 
 from fishy.helper.config import config
 

--- a/fishy/gui/gui.py
+++ b/fishy/gui/gui.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
-from typing import List, Callable, Optional, Dict, Any
 import tkinter as tk
+from typing import Callable, Optional, Dict, Any
 import queue
 import threading
 

--- a/fishy/gui/gui.py
+++ b/fishy/gui/gui.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
-from tkinter import OptionMenu, Button, IntVar
 from typing import List, Callable, Optional, Dict, Any
+import tkinter as tk
 import queue
 import threading
 
@@ -35,8 +35,8 @@ class GUI:
         self._console = None
         self._start_button = None
         self._notify_check = None
-        self._engine_select: Optional[OptionMenu] = None
-        self._config_button: Optional[Button] = None
+        self._engine_select: Optional[tk.OptionMenu] = None
+        self._config_button: Optional[tk.Button] = None
         self._engine_var = None
 
         self._thread = threading.Thread(target=self.create, args=())

--- a/fishy/gui/gui.py
+++ b/fishy/gui/gui.py
@@ -1,20 +1,21 @@
 import logging
-import uuid
-import tkinter as tk
-from typing import Callable, Optional, Dict, Any
 import queue
 import threading
+import tkinter as tk
+import uuid
+from typing import Any, Callable, Dict, Optional
 
-from fishy.web import web
 from ttkthemes import ThemedTk
 
 from fishy.engine.common.event_handler import EngineEventHandler
 from fishy.gui import config_top
 from fishy.gui.funcs import GUIFuncs
-from . import main_gui
-from .log_config import GUIStreamHandler
+from fishy.web import web
+
 from ..helper.config import config
 from ..helper.helper import wait_until
+from . import main_gui
+from .log_config import GUIStreamHandler
 
 
 class GUI:

--- a/fishy/gui/log_config.py
+++ b/fishy/gui/log_config.py
@@ -1,6 +1,5 @@
-from logging import StreamHandler
-
 import typing
+from logging import StreamHandler
 
 if typing.TYPE_CHECKING:
     from . import GUI

--- a/fishy/gui/main_gui.py
+++ b/fishy/gui/main_gui.py
@@ -2,19 +2,18 @@ import logging
 import time
 import tkinter as tk
 import tkinter.ttk as ttk
+import typing
 
-from fishy.web import web
 from ttkthemes import ThemedTk
 
 from fishy import helper
-
-import typing
-
 from fishy.helper import hotkey
-from .discord_login import discord_login
+from fishy.web import web
+
+from ..constants import chalutier, lam2
 from ..helper.config import config
 from ..helper.hotkey import Key
-from ..constants import chalutier, lam2
+from .discord_login import discord_login
 
 if typing.TYPE_CHECKING:
     from . import GUI

--- a/fishy/gui/main_gui.py
+++ b/fishy/gui/main_gui.py
@@ -1,7 +1,7 @@
 import logging
 import time
-from tkinter import *
-from tkinter.ttk import *
+import tkinter as tk
+import tkinter.ttk as ttk
 
 from fishy.web import web
 from ttkthemes import ThemedTk
@@ -36,14 +36,14 @@ def _create(gui: 'GUI'):
     gui._root.iconbitmap(helper.manifest_file('icon.ico'))
 
     # region menu
-    menubar = Menu(gui._root)
+    menubar = tk.Menu(gui._root)
 
-    filemenu = Menu(menubar, tearoff=0)
+    filemenu = tk.Menu(menubar, tearoff=0)
 
     login = web.is_logged_in()
-    gui.login = IntVar()
+    gui.login = tk.IntVar()
     gui.login.set(1 if login > 0 else 0)
-    state = DISABLED if login == -1 else ACTIVE
+    state = tk.DISABLED if login == -1 else tk.ACTIVE
     filemenu.add_checkbutton(label="Login", command=lambda: discord_login(gui), variable=gui.login, state=state)
     filemenu.add_command(label="Create Shortcut", command=lambda: helper.create_shortcut(False))
     # filemenu.add_command(label="Create Anti-Ghost Shortcut", command=lambda: helper.create_shortcut(True))
@@ -52,7 +52,7 @@ def _create(gui: 'GUI'):
         config.set("dark_mode", not config.get("dark_mode", True))
         gui._start_restart = True
 
-    dark_mode_var = IntVar()
+    dark_mode_var = tk.IntVar()
     dark_mode_var.set(int(config.get('dark_mode', True)))
     filemenu.add_checkbutton(label="Dark Mode", command=_toggle_mode,
                              variable=dark_mode_var)
@@ -72,11 +72,11 @@ def _create(gui: 'GUI'):
     filemenu.add_command(label=chaEntry, command=installer)
     menubar.add_cascade(label="Options", menu=filemenu)
 
-    debug_menu = Menu(menubar, tearoff=0)
+    debug_menu = tk.Menu(menubar, tearoff=0)
     debug_menu.add_command(label="Check PixelVal",
                            command=lambda: gui.engine.check_pixel_val())
 
-    debug_var = IntVar()
+    debug_var = tk.IntVar()
     debug_var.set(int(config.get('debug', False)))
 
     def keep_console():
@@ -87,7 +87,7 @@ def _create(gui: 'GUI'):
     debug_menu.add_command(label="Restart", command=helper.restart)
     menubar.add_cascade(label="Debug", menu=debug_menu)
 
-    help_menu = Menu(menubar, tearoff=0)
+    help_menu = tk.Menu(menubar, tearoff=0)
     help_menu.add_command(label="Need Help?", command=lambda: helper.open_web("http://discord.definex.in"))
     help_menu.add_command(label="Donate", command=lambda: helper.open_web("https://paypal.me/AdamSaudagar"))
     menubar.add_cascade(label="Help", menu=help_menu)
@@ -96,29 +96,29 @@ def _create(gui: 'GUI'):
     # endregion
 
     # region console
-    gui._console = Text(gui._root, state='disabled', wrap='none', background="#707070", fg="#ffffff")
-    gui._console.pack(fill=BOTH, expand=True, pady=(15, 15), padx=(10, 10))
-    gui._console.mark_set("sentinel", INSERT)
-    gui._console.config(state=DISABLED)
+    gui._console = tk.Text(gui._root, state='disabled', wrap='none', background="#707070", fg="#ffffff")
+    gui._console.pack(fill=tk.BOTH, expand=True, pady=(15, 15), padx=(10, 10))
+    gui._console.mark_set("sentinel", tk.INSERT)
+    gui._console.config(state=tk.DISABLED)
     # endregion
 
     # region controls
-    start_frame = Frame(gui._root)
+    start_frame = ttk.Frame(gui._root)
 
-    gui._engine_var = StringVar(start_frame)
+    gui._engine_var = tk.StringVar(start_frame)
     labels = list(engines.keys())
     last_started = config.get("last_started", labels[0])
-    gui._engine_select = OptionMenu(start_frame, gui._engine_var, last_started, *labels)
-    gui._engine_select.pack(side=LEFT)
+    gui._engine_select = ttk.OptionMenu(start_frame, gui._engine_var, last_started, *labels)
+    gui._engine_select.pack(side=tk.LEFT)
 
-    gui._config_button = Button(start_frame, text="⚙", width=0, command=lambda: engines[gui._engine_var.get()][0]())
-    gui._config_button.pack(side=RIGHT)
+    gui._config_button = ttk.Button(start_frame, text="⚙", width=0, command=lambda: engines[gui._engine_var.get()][0]())
+    gui._config_button.pack(side=tk.RIGHT)
 
-    gui._start_button = Button(start_frame, text=gui._get_start_stop_text(), width=25,
+    gui._start_button = ttk.Button(start_frame, text=gui._get_start_stop_text(), width=25,
                                command=gui.funcs.start_engine)
-    gui._start_button.pack(side=RIGHT)
+    gui._start_button.pack(side=tk.RIGHT)
 
-    start_frame.pack(padx=(10, 10), pady=(5, 15), fill=X)
+    start_frame.pack(padx=(10, 10), pady=(5, 15), fill=tk.X)
     # endregion
 
     _apply_theme(gui)
@@ -132,7 +132,7 @@ def _create(gui: 'GUI'):
     # noinspection PyProtectedMember
     def set_destroy():
         if gui._bot_running:
-            if not messagebox.askyesno(title="Quit?", message="Bot engine running. Quit Anyway?"):
+            if not tk.messagebox.askyesno(title="Quit?", message="Bot engine running. Quit Anyway?"):
                 return
 
         config.set("win_loc", gui._root.geometry())

--- a/fishy/gui/splash.py
+++ b/fishy/gui/splash.py
@@ -1,6 +1,6 @@
 import time
 from multiprocessing import Process
-from tkinter import *
+import tkinter as tk
 from PIL import Image, ImageTk
 
 from fishy.helper.config import config
@@ -9,7 +9,7 @@ from fishy.helper import helper
 
 def show(win_loc):
     dim=(300,200)
-    top = Tk()
+    top = tk.Tk()
 
     top.overrideredirect(True)
     top.lift()
@@ -18,11 +18,11 @@ def show(win_loc):
     top.resizable(False, False)
     top.iconbitmap(helper.manifest_file('icon.ico'))
 
-    canvas = Canvas(top, width=dim[0], height=dim[1], bg='white')
+    canvas = tk.Canvas(top, width=dim[0], height=dim[1], bg='white')
     canvas.pack()
     top.image = Image.open(helper.manifest_file('fishybot_logo.png')).resize(dim)
     top.image = ImageTk.PhotoImage(top.image)
-    canvas.create_image(0, 0, anchor=NW, image=top.image)
+    canvas.create_image(0, 0, anchor=tk.NW, image=top.image)
 
     # Position splash at the center of the main window
 

--- a/fishy/gui/splash.py
+++ b/fishy/gui/splash.py
@@ -1,10 +1,11 @@
 import time
-from multiprocessing import Process
 import tkinter as tk
+from multiprocessing import Process
+
 from PIL import Image, ImageTk
 
-from fishy.helper.config import config
 from fishy.helper import helper
+from fishy.helper.config import config
 
 
 def show(win_loc):

--- a/fishy/gui/terms_gui.py
+++ b/fishy/gui/terms_gui.py
@@ -1,7 +1,7 @@
-import webbrowser
+import re
 import tkinter as tk
 import tkinter.ttk as ttk
-import re
+import webbrowser
 
 from PIL import Image, ImageTk
 

--- a/fishy/gui/terms_gui.py
+++ b/fishy/gui/terms_gui.py
@@ -1,6 +1,6 @@
 import webbrowser
-from tkinter import *
-from tkinter.ttk import *
+import tkinter as tk
+import tkinter.ttk as ttk
 import re
 
 from PIL import Image, ImageTk
@@ -25,41 +25,41 @@ def _run_terms_window():
         root.destroy()
 
     def disable_enable_button():
-        accept_button.config(state=NORMAL if check_value.get() else DISABLED)
+        accept_button.config(state=tk.NORMAL if check_value.get() else tk.DISABLED)
 
-    root = Tk()
+    root = tk.Tk()
     message = f'I agree to the [Terms of Service and Privacy Policy]({web.get_terms_page()})'
     root.title("EULA")
     root.resizable(False, False)
     root.iconbitmap(helper.manifest_file('icon.ico'))
 
-    f = Frame(root)
-    canvas = Canvas(f, width=300, height=200)
+    f = ttk.Frame(root)
+    canvas = tk.Canvas(f, width=300, height=200)
     canvas.pack()
     root.image = Image.open(helper.manifest_file('fishybot_logo.png')).resize((300, 200))
     root.image = ImageTk.PhotoImage(root.image)
-    canvas.create_image(0, 0, anchor=NW, image=root.image)
+    canvas.create_image(0, 0, anchor=tk.NW, image=root.image)
 
-    check_value = IntVar(0)
+    check_value = tk.IntVar(0)
 
-    g1 = Frame(f)
-    Checkbutton(g1, command=disable_enable_button, variable=check_value).pack(side=LEFT)
-    text = Text(g1, width=len(hyperlinkPattern.sub(r'\g<title>', message)),
+    g1 = ttk.Frame(f)
+    ttk.Checkbutton(g1, command=disable_enable_button, variable=check_value).pack(side=tk.LEFT)
+    text = tk.Text(g1, width=len(hyperlinkPattern.sub(r'\g<title>', message)),
                 height=1, borderwidth=0, highlightthickness=0)
     text["background"] = root["background"]
 
     _format_hyper_link(text, message)
-    text.config(state=DISABLED)
-    text.pack(side=LEFT)
+    text.config(state=tk.DISABLED)
+    text.pack(side=tk.LEFT)
     g1.pack()
 
     f.pack(padx=(10, 10), pady=(20, 20))
 
-    g2 = Frame(f)
-    accept_button = Button(g2, text="Accept",
+    g2 = ttk.Frame(f)
+    accept_button = ttk.Button(g2, text="Accept",
                            command=accept)
     accept_button.grid(row=0, column=0)
-    Button(g2, text="Deny",
+    ttk.Button(g2, text="Deny",
            command=lambda: root.destroy()).grid(row=0, column=1)
     g2.pack(pady=(5, 0))
     disable_enable_button()

--- a/fishy/gui/update_dialog.py
+++ b/fishy/gui/update_dialog.py
@@ -1,6 +1,5 @@
 from multiprocessing import Process, Manager
 import tkinter as tk
-import time
 
 from fishy import helper
 

--- a/fishy/gui/update_dialog.py
+++ b/fishy/gui/update_dialog.py
@@ -1,19 +1,19 @@
 from multiprocessing import Process, Manager
-from tkinter import *
+import tkinter as tk
 import time
 
 from fishy import helper
 
 def show(currentversion, newversion, returns):
-    top = Tk()
+    top = tk.Tk()
     top.title("A wild fishy update appeared!")
     top.iconbitmap(helper.manifest_file('icon.ico'))
 
-    dialogLabel = Label(top, text="There is a new fishy update available ("+currentversion+"->"+newversion+"). Do you want to update now?")
+    dialogLabel = tk.Label(top, text="There is a new fishy update available ("+currentversion+"->"+newversion+"). Do you want to update now?")
     dialogLabel.grid(row=0, columnspan=2, padx=5, pady=5)
 
-    cbVar = IntVar()
-    dialogCheckbutton = Checkbutton(top, text="don't ask again", variable=cbVar)
+    cbVar = tk.IntVar()
+    dialogCheckbutton = tk.Checkbutton(top, text="don't ask again", variable=cbVar)
     dialogCheckbutton.grid(row=1, columnspan=2, padx=5, pady=0)
     top.update()
     buttonWidth = int(dialogLabel.winfo_width()/2)-20
@@ -26,10 +26,10 @@ def show(currentversion, newversion, returns):
         returns[0],returns[1]=False, bool(cbVar.get())
         top.destroy()
 
-    pixelVirtual = PhotoImage(width=1, height=1) # trick to use buttonWidth as pixels, not #symbols
-    dialogBtnNo = Button(top, text="No " + str(chr(10005)),  fg='red4', command=_clickNo, image=pixelVirtual, width=buttonWidth, compound="c")
+    pixelVirtual = tk.PhotoImage(width=1, height=1) # trick to use buttonWidth as pixels, not #symbols
+    dialogBtnNo = tk.Button(top, text="No " + str(chr(10005)),  fg='red4', command=_clickNo, image=pixelVirtual, width=buttonWidth, compound="c")
     dialogBtnNo.grid(row=2, column=0, padx=5, pady=5)
-    dialogBtnYes = Button(top, text="Yes " + str(chr(10003)),  fg='green', command=_clickYes, image=pixelVirtual, width=buttonWidth, compound="c")
+    dialogBtnYes = tk.Button(top, text="Yes " + str(chr(10003)),  fg='green', command=_clickYes, image=pixelVirtual, width=buttonWidth, compound="c")
     dialogBtnYes.grid(row=2, column=1, padx=5, pady=5)
     dialogBtnYes.focus_set()
 

--- a/fishy/gui/update_dialog.py
+++ b/fishy/gui/update_dialog.py
@@ -1,7 +1,8 @@
-from multiprocessing import Process, Manager
 import tkinter as tk
+from multiprocessing import Manager, Process
 
 from fishy import helper
+
 
 def show(currentversion, newversion, returns):
     top = tk.Tk()

--- a/fishy/helper/__init__.py
+++ b/fishy/helper/__init__.py
@@ -1,6 +1,9 @@
 from .auto_update import auto_upgrade, upgrade_avail, versions
 from .config import Config
-from .helper import open_web, initialize_uid, install_thread_excepthook, unhandled_exception_logging, manifest_file, \
-    create_shortcut_first, addon_exists, get_addonversion, install_addon, remove_addon, restart, create_shortcut, \
-    not_implemented, update, get_savedvarsdir, playsound_multiple
+from .helper import (addon_exists, create_shortcut, create_shortcut_first,
+                     get_addonversion, get_savedvarsdir, initialize_uid,
+                     install_addon, install_thread_excepthook, manifest_file,
+                     not_implemented, open_web, playsound_multiple,
+                     remove_addon, restart, unhandled_exception_logging,
+                     update)
 from .luaparser import sv_color_extract

--- a/fishy/helper/auto_update.py
+++ b/fishy/helper/auto_update.py
@@ -11,6 +11,7 @@ from os import execl
 
 from bs4 import BeautifulSoup
 
+
 def _hr_version(v):
     return '.'.join([str(x) for x in v])
     #return str(v[0])+"."+str(v[1])+"."+str(v[2])

--- a/fishy/helper/config.py
+++ b/fishy/helper/config.py
@@ -3,7 +3,6 @@ config.py
 Saves configuration in file as json file
 """
 import json
-import logging
 import os
 
 # path to save the configuration file

--- a/fishy/helper/config.py
+++ b/fishy/helper/config.py
@@ -4,9 +4,9 @@ Saves configuration in file as json file
 """
 import json
 import os
-
 # path to save the configuration file
 from typing import Optional
+
 from event_scheduler import EventScheduler
 
 

--- a/fishy/helper/helper.py
+++ b/fishy/helper/helper.py
@@ -6,21 +6,19 @@ import threading
 import time
 import traceback
 import webbrowser
-import requests
-from playsound import playsound
+from hashlib import md5
 from io import BytesIO
 from threading import Thread
+from uuid import uuid1
 from zipfile import ZipFile
 
-from uuid import uuid1
-from hashlib import md5
-
+import requests
+import winshell
+from playsound import playsound
 from win32com.client import Dispatch
 from win32comext.shell import shell, shellcon
 
 import fishy
-import winshell
-
 from fishy import web
 
 

--- a/fishy/helper/hotkey.py
+++ b/fishy/helper/hotkey.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from threading import Thread
-from typing import Dict, Callable, Optional
+from typing import Callable, Dict, Optional
 
 import keyboard
 

--- a/fishy/helper/hotkey_process.py
+++ b/fishy/helper/hotkey_process.py
@@ -1,8 +1,8 @@
 import time
+from multiprocessing import Process, Queue
 from threading import Thread
 
 import mouse
-from multiprocessing import Process, Queue
 
 
 def event_triggered(queue, e):

--- a/fishy/helper/luaparser.py
+++ b/fishy/helper/luaparser.py
@@ -1,6 +1,7 @@
-import os
 import logging
+import os
 from math import floor
+
 from .helper import get_savedvarsdir
 
 

--- a/fishy/web/__init__.py
+++ b/fishy/web/__init__.py
@@ -1,2 +1,3 @@
 from .urls import get_notification_page, get_terms_page
-from .web import register_user, send_notification, send_fish_caught, is_subbed, unsub, get_session, sub
+from .web import (get_session, is_subbed, register_user, send_fish_caught,
+                  send_notification, sub, unsub)

--- a/fishy/web/web.py
+++ b/fishy/web/web.py
@@ -3,10 +3,11 @@ from whatsmyip.ip import get_ip
 from whatsmyip.providers import GoogleDnsProvider
 
 from fishy import helper
+
+from ..constants import apiversion
+from ..helper.config import config
 from . import urls
 from .decorators import fallback, uses_session
-from ..helper.config import config
-from ..constants import apiversion
 
 _session_id = None
 

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,16 @@ https://packaging.python.org/guides/distributing-packages-using-setuptools/
 https://github.com/pypa/sampleproject
 """
 
-# Always prefer setuptools over distutils
-from setuptools import setup, find_packages
-from os import path
 # io.open is needed for projects that support Python 2.7
 # It ensures open() defaults to text mode with universal newlines,
 # and accepts an argument to specify the text encoding
 # Python 3 only projects can skip this import
 from io import open
+from os import path
+
+# Always prefer setuptools over distutils
+from setuptools import find_packages, setup
+
 from fishy import __version__
 
 here = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
This PR is only a cleanup changing imports.
1. Removes star imports of tkinter and tkinter.ttk and uses qualifiers "tk" and "ttk" for objects of these libs instead
2. Removes unused imports detected by flake8, except in \_\_init\_\_.py files, which are kept as is
3. Sorts imports with `isort .`, except in libs/tkhtmlview