### PR TITLE
limit decode() by type QRCODE

### DIFF
--- a/fishy/engine/fullautofisher/qr_detection.py
+++ b/fishy/engine/fullautofisher/qr_detection.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import cv2
 import numpy as np
-from pyzbar.pyzbar import decode
+from pyzbar.pyzbar import decode, ZBarSymbol
 
 from fishy.helper.helper import get_documents
 
@@ -28,7 +28,8 @@ def get_qr_location(og_img):
             mask = np.zeros_like(img)
             cv2.drawContours(mask, cnt, i, 255, -1)
             x, y, w, h = cv2.boundingRect(cnt[i])
-            qr_result = decode(og_img[y:h + y, x:w + x])
+            qr_result = decode(og_img[y:h + y, x:w + x],
+                symbols=[ZBarSymbol.QRCODE])
             if qr_result:
                 valid_crops.append(((x, y, x + w, y + h), area))
 
@@ -38,7 +39,7 @@ def get_qr_location(og_img):
 # noinspection PyBroadException
 def get_values_from_image(img):
     try:
-        for qr in decode(img):
+        for qr in decode(img, symbols=[ZBarSymbol.QRCODE]):
             vals = qr.data.decode('utf-8').split(",")
             return float(vals[0]), float(vals[1]), float(vals[2])
 


### PR DESCRIPTION
improves qr decoding by limiting to type ZBarSymbol.QRCODE

as i work through things i started to get these messages which someone on stack exchange was likely because we werent even using pdf417 codes and that we could limit them in zbar. i made the 3 lines of change and it seems to help quite a bit. im guessing it will help in the current release as well so i prepared this pr.

```WARNING: .\zbar\decoder\pdf417.c:89: <unknown>: Assertion "g[0] >= 0 && g[1] >= 0 && g[2] >= 0" failed.
        dir=0 sig=1198a k=0 g0=699 g1=b76 g2=ffffffff buf[0000]=
WARNING: .\zbar\decoder\pdf417.c:89: <unknown>: Assertion "g[0] >= 0 && g[1] >= 0 && g[2] >= 0" failed.
        dir=0 sig=290a k=3 g0=b9f g1=ffffffff g2=ae4 buf[0000]=
WARNING: .\zbar\decoder\pdf417.c:89: <unknown>: Assertion "g[0] >= 0 && g[1] >= 0 && g[2] >= 0" failed.
        dir=0 sig=290a k=3 g0=b9f g1=ffffffff g2=ae4 buf[0000]=
WARNING: .\zbar\decoder\pdf417.c:89: <unknown>: Assertion "g[0] >= 0 && g[1] >= 0 && g[2] >= 0" failed.
        dir=0 sig=1bf00 k=0 g0=000 g1=ab0 g2=ffffffff buf[0000]=
WARNING: .\zbar\decoder\pdf417.c:73: <unknown>: Assertion "clst >= 0 && clst < 9" failed.
        dir=0 sig=1b0120 k=ffffffff buf[0000]=
WARNING: .\zbar\decoder\pdf417.c:73: <unknown>: Assertion "clst >= 0 && clst < 9" failed.
        dir=1 sig=7e02 k=9 buf[0000]=
WARNING: .\zbar\decoder\pdf417.c:89: <unknown>: Assertion "g[0] >= 0 && g[1] >= 0 && g[2] >= 0" failed.
        dir=0 sig=13814 k=3 g0=ac4 g1=ffffffff g2=c74 buf[0000]=```
        
        