### PR TITLE
No thread left behind

### DIFF
--- a/fishy/__main__.py
+++ b/fishy/__main__.py
@@ -79,6 +79,8 @@ def main():
     pil_logger = logging.getLogger('PIL')
     pil_logger.setLevel(logging.INFO)
 
+    # todo set log level info for d3dshot too
+
     window_to_hide = win32gui.GetForegroundWindow()
 
     if not gui.check_eula():

--- a/fishy/__main__.py
+++ b/fishy/__main__.py
@@ -70,7 +70,7 @@ def initialize(window_to_hide):
 def main():
     active.init()
     config.init()
-    splash.start()
+    finish_splash = splash.start()
     hotkey.init()
 
     print("launching please wait...")
@@ -86,7 +86,7 @@ def main():
         return
 
     bot = EngineEventHandler(lambda: gui_window)
-    gui_window = GUI(lambda: bot)
+    gui_window = GUI(lambda: bot, finish_splash)
 
     hotkey.start()
 
@@ -96,7 +96,8 @@ def main():
     gui_window.start()
     active.start()
 
-    bot.start_event_handler()
+    bot.start_event_handler()   # main thread loop
+
     config.stop()
     hotkey.stop()
     active.stop()

--- a/fishy/__main__.py
+++ b/fishy/__main__.py
@@ -7,13 +7,13 @@ import win32con
 import win32gui
 
 import fishy
-from fishy import gui, helper, web
+from fishy.gui import GUI, splash, update_dialog, check_eula
+from fishy import helper, web
 from fishy.engine.common.event_handler import EngineEventHandler
-from fishy.gui import GUI, splash, update_dialog
-from fishy.helper import hotkey, auto_update
+from fishy.gui.log_config import GuiLogger
+from fishy.helper import hotkey
 from fishy.helper.active_poll import active
 from fishy.helper.config import config
-from fishy.helper.helper import print_exc
 from fishy.helper.hotkey.hotkey_process import hotkey
 from fishy.helper.migration import Migration
 
@@ -57,34 +57,31 @@ def main():
     print("launching please wait...")
 
     config.init()
-    if not gui.check_eula():
+    if not check_eula():
         return
 
     finish_splash = splash.start()
+    logger = GuiLogger()
     config.start_backup_scheduler()
     active.init()
     hotkey.init()
 
     def on_gui_load():
         finish_splash()
-        update_dialog.check_update(gui_window)
-
-    info_logger = ["comtypes", "PIL"]
-    for i in info_logger:
-        _logger = logging.getLogger(i)
-        _logger.setLevel(logging.INFO)
+        update_dialog.check_update(gui)
+        logger.connect(gui)
 
     window_to_hide = win32gui.GetForegroundWindow()
 
-    bot = EngineEventHandler(lambda: gui_window)
-    gui_window = GUI(lambda: bot, on_gui_load)
+    bot = EngineEventHandler(lambda: gui)
+    gui = GUI(lambda: bot, on_gui_load)
 
     hotkey.start()
 
     logging.info(f"Fishybot v{fishy.__version__}")
     initialize(window_to_hide)
 
-    gui_window.start()
+    gui.start()
     active.start()
 
     bot.start_event_handler()   # main thread loop

--- a/fishy/__main__.py
+++ b/fishy/__main__.py
@@ -36,7 +36,7 @@ def initialize(window_to_hide):
 
     if new_session is None:
         logging.error("Couldn't create a session, some features might not work")
-    print(f"created session {new_session}")
+    logging.debug(f"created session {new_session}")
 
     try:
         is_admin = os.getuid() == 0
@@ -54,6 +54,8 @@ def initialize(window_to_hide):
 
 
 def main():
+    print("launching please wait...")
+
     config.init()
     if not gui.check_eula():
         return
@@ -67,12 +69,10 @@ def main():
         finish_splash()
         update_dialog.check_update(gui_window)
 
-    print("launching please wait...")
-
     info_logger = ["comtypes", "PIL"]
     for i in info_logger:
-        pil_logger = logging.getLogger(i)
-        pil_logger.setLevel(logging.INFO)
+        _logger = logging.getLogger(i)
+        _logger.setLevel(logging.INFO)
 
     window_to_hide = win32gui.GetForegroundWindow()
 

--- a/fishy/__main__.py
+++ b/fishy/__main__.py
@@ -31,9 +31,9 @@ def initialize(window_to_hide):
     Migration.migrate()
 
     helper.create_shortcut_first()
-    helper.initialize_uid()
 
     new_session = web.get_session()
+
     if new_session is None:
         logging.error("Couldn't create a session, some features might not work")
     print(f"created session {new_session}")
@@ -58,9 +58,9 @@ def main():
     if not gui.check_eula():
         return
 
+    finish_splash = splash.start()
     config.start_backup_scheduler()
     active.init()
-    finish_splash = splash.start()
     hotkey.init()
 
     def on_gui_load():

--- a/fishy/__main__.py
+++ b/fishy/__main__.py
@@ -68,8 +68,12 @@ def initialize(window_to_hide):
 
 
 def main():
-    active.init()
     config.init()
+    if not gui.check_eula():
+        return
+
+    config.start_backup_scheduler()
+    active.init()
     finish_splash = splash.start()
     hotkey.init()
 
@@ -81,9 +85,6 @@ def main():
         pil_logger.setLevel(logging.INFO)
 
     window_to_hide = win32gui.GetForegroundWindow()
-
-    if not gui.check_eula():
-        return
 
     bot = EngineEventHandler(lambda: gui_window)
     gui_window = GUI(lambda: bot, finish_splash)
@@ -98,9 +99,9 @@ def main():
 
     bot.start_event_handler()   # main thread loop
 
-    config.stop()
     hotkey.stop()
     active.stop()
+    config.stop()
 
 
 if __name__ == "__main__":

--- a/fishy/__main__.py
+++ b/fishy/__main__.py
@@ -2,19 +2,18 @@ import ctypes
 import logging
 import os
 import sys
-import traceback
 
 import win32con
 import win32gui
 
 import fishy
 from fishy import gui, helper, web
-from fishy.constants import chalutier, lam2, fishyqr, libgps
 from fishy.engine.common.event_handler import EngineEventHandler
 from fishy.gui import GUI, splash, update_dialog
 from fishy.helper import hotkey
 from fishy.helper.active_poll import active
 from fishy.helper.config import config
+from fishy.helper.helper import print_exc
 from fishy.helper.hotkey.hotkey_process import hotkey
 from fishy.helper.migration import Migration
 
@@ -58,7 +57,7 @@ def initialize(window_to_hide):
             if update_now:
                 helper.auto_upgrade()
     except Exception:
-        logging.error(traceback.format_exc())
+        print_exc()
 
     if not config.get("debug", False) and check_window_name(win32gui.GetWindowText(window_to_hide)):
         win32gui.ShowWindow(window_to_hide, win32con.SW_HIDE)
@@ -76,10 +75,10 @@ def main():
 
     print("launching please wait...")
 
-    pil_logger = logging.getLogger('PIL')
-    pil_logger.setLevel(logging.INFO)
-
-    # todo set log level info for d3dshot too
+    info_logger = ["comtypes", "PIL"]
+    for i in info_logger:
+        pil_logger = logging.getLogger(i)
+        pil_logger.setLevel(logging.INFO)
 
     window_to_hide = win32gui.GetForegroundWindow()
 

--- a/fishy/engine/common/IEngine.py
+++ b/fishy/engine/common/IEngine.py
@@ -1,15 +1,12 @@
 import logging
-import traceback
 import typing
 from threading import Thread
 from typing import Callable
 
 import cv2
-from playsound import playsound
 
 from fishy.engine.common.window import WindowClient
 from fishy.gui.funcs import GUIFuncsMock
-from fishy.helper import helper
 from fishy.helper.helper import print_exc
 
 if typing.TYPE_CHECKING:
@@ -23,7 +20,7 @@ class IEngine:
         # 0 - off, 1 - running, 2 - quitting
         self.state = 0
         self.window = None
-        self.thread: Thread = None
+        self.thread = None
 
     @property
     def gui(self):

--- a/fishy/engine/common/IEngine.py
+++ b/fishy/engine/common/IEngine.py
@@ -23,7 +23,7 @@ class IEngine:
         # 0 - off, 1 - running, 2 - quitting
         self.state = 0
         self.window = None
-        self.thread = None
+        self.thread: Thread = None
 
     @property
     def gui(self):
@@ -46,6 +46,10 @@ class IEngine:
         self.state = 1
         self.thread = Thread(target=self._crash_safe)
         self.thread.start()
+
+    def join(self):
+        if self.thread:
+            self.thread.join()
 
     def turn_off(self):
         """

--- a/fishy/engine/common/IEngine.py
+++ b/fishy/engine/common/IEngine.py
@@ -21,6 +21,7 @@ class IEngine:
         self.state = 0
         self.window = None
         self.thread = None
+        self.name = "default"
 
     @property
     def gui(self):
@@ -46,6 +47,7 @@ class IEngine:
 
     def join(self):
         if self.thread:
+            logging.debug(f"waiting for {self.name} engine")
             self.thread.join()
 
     def turn_off(self):
@@ -54,23 +56,26 @@ class IEngine:
         its the responsibility of the thread to shut turn itself off
         """
         if self.state == 1:
-            logging.info("turning off...")
+            logging.debug(f"sending turn off signal to {self.name} engine")
             self.state = 2
         else:
-            logging.error("engine already signaled to turn off")
+            logging.debug(f"{self.name} engine already signaled to turn off ")
             # todo: implement force turn off on repeated calls
 
     # noinspection PyBroadException
     def _crash_safe(self):
-        self.window = WindowClient(color=cv2.COLOR_RGB2GRAY, show_name="fishy debug")
+        logging.debug(f"starting {self.name} engine thread")
+        self.window = WindowClient(color=cv2.COLOR_RGB2GRAY, show_name=f"{self.name} debug")
         self.gui.bot_started(True)
         try:
             self.run()
         except Exception:
+            logging.error(f"Unhandled exception occurred while running {self.name} engine")
             print_exc()
         self.state = 0
         self.gui.bot_started(False)
         self.window.destroy()
+        logging.debug(f"{self.name} engine thread safely exiting")
 
     def run(self):
         raise NotImplementedError

--- a/fishy/engine/common/IEngine.py
+++ b/fishy/engine/common/IEngine.py
@@ -4,8 +4,10 @@ import typing
 from threading import Thread
 from typing import Callable
 
+import cv2
 from playsound import playsound
 
+from fishy.engine.common.window import WindowClient
 from fishy.gui.funcs import GUIFuncsMock
 from fishy.helper import helper
 
@@ -58,6 +60,7 @@ class IEngine:
 
     # noinspection PyBroadException
     def _crash_safe(self):
+        self.window = WindowClient(color=cv2.COLOR_RGB2GRAY, show_name="fishy debug")
         self.gui.bot_started(True)
         try:
             self.run()
@@ -65,6 +68,7 @@ class IEngine:
             traceback.print_exc()
         self.state = 0
         self.gui.bot_started(False)
+        self.window.destroy()
 
     def run(self):
         raise NotImplementedError

--- a/fishy/engine/common/IEngine.py
+++ b/fishy/engine/common/IEngine.py
@@ -29,15 +29,18 @@ class IEngine:
 
         return self.get_gui().funcs
 
+    @property
+    def start(self):
+        return self.state == 1
+
     def toggle_start(self):
-        if self.state == 1:
-            self.turn_off()
-        elif self.state == 0:
+        if self.state == 0:
+            self.turn_on()
+        else:
             self.turn_on()
 
     def turn_on(self):
         self.state = 1
-        playsound(helper.manifest_file("beep.wav"), False)
         self.thread = Thread(target=self._crash_safe)
         self.thread.start()
 
@@ -46,8 +49,12 @@ class IEngine:
         this method only signals the thread to close using start flag,
         its the responsibility of the thread to shut turn itself off
         """
-        self.state = 2
-        helper.playsound_multiple(helper.manifest_file("beep.wav"))
+        if self.state == 1:
+            logging.info("turning off...")
+            self.state = 2
+        else:
+            logging.error("engine already signaled to turn off")
+            # todo: implement force turn off on repeated calls
 
     # noinspection PyBroadException
     def _crash_safe(self):

--- a/fishy/engine/common/IEngine.py
+++ b/fishy/engine/common/IEngine.py
@@ -1,19 +1,24 @@
+import logging
+import traceback
 import typing
-from abc import ABC, abstractmethod
 from threading import Thread
 from typing import Callable
 
+from playsound import playsound
+
 from fishy.gui.funcs import GUIFuncsMock
+from fishy.helper import helper
 
 if typing.TYPE_CHECKING:
     from fishy.gui import GUI
 
 
-class IEngine(ABC):
+class IEngine:
 
     def __init__(self, gui_ref: 'Callable[[], GUI]'):
         self.get_gui = gui_ref
-        self.start = False
+        # 0 - off, 1 - running, 2 - quitting
+        self.state = 0
         self.window = None
         self.thread = None
 
@@ -24,10 +29,35 @@ class IEngine(ABC):
 
         return self.get_gui().funcs
 
-    @abstractmethod
     def toggle_start(self):
-        ...
+        if self.state == 1:
+            self.turn_off()
+        elif self.state == 0:
+            self.turn_on()
 
-    @abstractmethod
+    def turn_on(self):
+        self.state = 1
+        playsound(helper.manifest_file("beep.wav"), False)
+        self.thread = Thread(target=self._crash_safe)
+        self.thread.start()
+
+    def turn_off(self):
+        """
+        this method only signals the thread to close using start flag,
+        its the responsibility of the thread to shut turn itself off
+        """
+        self.state = 2
+        helper.playsound_multiple(helper.manifest_file("beep.wav"))
+
+    # noinspection PyBroadException
+    def _crash_safe(self):
+        self.gui.bot_started(True)
+        try:
+            self.run()
+        except Exception:
+            traceback.print_exc()
+        self.state = 0
+        self.gui.bot_started(False)
+
     def run(self):
-        ...
+        raise NotImplementedError

--- a/fishy/engine/common/IEngine.py
+++ b/fishy/engine/common/IEngine.py
@@ -10,6 +10,7 @@ from playsound import playsound
 from fishy.engine.common.window import WindowClient
 from fishy.gui.funcs import GUIFuncsMock
 from fishy.helper import helper
+from fishy.helper.helper import print_exc
 
 if typing.TYPE_CHECKING:
     from fishy.gui import GUI
@@ -39,7 +40,7 @@ class IEngine:
         if self.state == 0:
             self.turn_on()
         else:
-            self.turn_on()
+            self.turn_off()
 
     def turn_on(self):
         self.state = 1
@@ -65,7 +66,7 @@ class IEngine:
         try:
             self.run()
         except Exception:
-            traceback.print_exc()
+            print_exc()
         self.state = 0
         self.gui.bot_started(False)
         self.window.destroy()

--- a/fishy/engine/common/event_handler.py
+++ b/fishy/engine/common/event_handler.py
@@ -1,6 +1,8 @@
 import logging
 import time
 
+from fishy.helper import auto_update
+
 from fishy.engine import SemiFisherEngine
 from fishy.engine.fullautofisher.engine import FullAuto
 
@@ -22,7 +24,10 @@ class IEngineHandler:
     def check_pixel_val(self):
         ...
 
-    def quit(self):
+    def set_update(self, version):
+        ...
+
+    def quit_me(self):
         ...
 
 
@@ -31,6 +36,9 @@ class EngineEventHandler(IEngineHandler):
         super().__init__()
         self.event_handler_running = True
         self.event = []
+
+        self.update_flag = False
+        self.to_version = ""
 
         self.semi_fisher_engine = SemiFisherEngine(gui_ref)
         self.full_fisher_engine = FullAuto(gui_ref)
@@ -57,7 +65,16 @@ class EngineEventHandler(IEngineHandler):
 
         self.event.append(func)
 
-    def quit(self):
+    def set_update(self, version):
+        self.to_version = version
+        self.update_flag = True
+        self.quit_me()
+
+    def stop(self):
+        if self.update_flag:
+            auto_update.update_now(self.to_version)
+
+    def quit_me(self):
         def func():
             if self.semi_fisher_engine.start:
                 self.semi_fisher_engine.turn_off()

--- a/fishy/engine/common/event_handler.py
+++ b/fishy/engine/common/event_handler.py
@@ -71,6 +71,8 @@ class EngineEventHandler(IEngineHandler):
         self.quit_me()
 
     def stop(self):
+        self.semi_fisher_engine.join()
+        self.full_fisher_engine.join()
         if self.update_flag:
             auto_update.update_now(self.to_version)
 

--- a/fishy/engine/common/event_handler.py
+++ b/fishy/engine/common/event_handler.py
@@ -5,6 +5,7 @@ from fishy.engine import SemiFisherEngine
 from fishy.engine.fullautofisher.engine import FullAuto
 
 
+# to test only gui without engine code interfering
 class IEngineHandler:
     def __init__(self):
         ...
@@ -58,7 +59,11 @@ class EngineEventHandler(IEngineHandler):
 
     def quit(self):
         def func():
-            self.semi_fisher_engine.start = False
+            if self.semi_fisher_engine.start:
+                self.semi_fisher_engine.turn_off()
+            if self.full_fisher_engine.start:
+                self.semi_fisher_engine.turn_off()
+
             self.event_handler_running = False
 
         self.event.append(func)

--- a/fishy/engine/common/qr_detection.py
+++ b/fishy/engine/common/qr_detection.py
@@ -1,12 +1,6 @@
-import logging
-import os
-from datetime import datetime
-
 import cv2
 import numpy as np
 from pyzbar.pyzbar import decode, ZBarSymbol
-
-from fishy.helper.helper import get_documents
 
 
 def image_pre_process(img):

--- a/fishy/engine/common/qr_detection.py
+++ b/fishy/engine/common/qr_detection.py
@@ -38,7 +38,7 @@ def get_qr_location(og_img):
             cv2.drawContours(mask, cnt, i, 255, -1)
             x, y, w, h = cv2.boundingRect(cnt[i])
             qr_result = decode(og_img[y:h + y, x:w + x],
-                symbols=[ZBarSymbol.QRCODE])
+                               symbols=[ZBarSymbol.QRCODE])
             if qr_result:
                 valid_crops.append(((x, y, x + w, y + h), area))
 

--- a/fishy/engine/common/qr_detection.py
+++ b/fishy/engine/common/qr_detection.py
@@ -47,14 +47,7 @@ def get_qr_location(og_img):
 
 # noinspection PyBroadException
 def get_values_from_image(img):
-    try:
-        for qr in decode(img, symbols=[ZBarSymbol.QRCODE]):
-            vals = qr.data.decode('utf-8').split(",")
-            return tuple(float(v) for v in vals)
-
-        logging.error("FishyQR not found, try to drag it around and try again")
-        return None
-    except Exception:
-        logging.error("Couldn't read coods, make sure 'crop' calibration is correct")
-        cv2.imwrite(os.path.join(get_documents(), "fishy_failed_reads", f"{datetime.now()}.jpg"), img)
-        return None
+    for qr in decode(img, symbols=[ZBarSymbol.QRCODE]):
+        vals = qr.data.decode('utf-8').split(",")
+        return tuple(float(v) for v in vals)
+    return None

--- a/fishy/engine/common/window.py
+++ b/fishy/engine/common/window.py
@@ -47,9 +47,9 @@ class WindowClient:
             return None
 
         if not window_server.screen_ready():
-            print("waiting for screen...")
+            logging.debug("waiting for screen...")
             helper.wait_until(window_server.screen_ready)
-            print("screen ready, continuing...")
+            logging.debug("screen ready, continuing...")
 
         temp_img = WindowServer.Screen
 

--- a/fishy/engine/common/window.py
+++ b/fishy/engine/common/window.py
@@ -89,7 +89,7 @@ class WindowClient:
     def show(self, to_show, resize=None, func=None):
         """
         Displays the processed image for debugging purposes
-        :param ready_img: send ready image, just show the `ready_img` directly
+        :param to_show: false to destroy the window
         :param resize: scale the image to make small images more visible
         :param func: function to process the image
         """

--- a/fishy/engine/common/window.py
+++ b/fishy/engine/common/window.py
@@ -28,7 +28,7 @@ class WindowClient:
             window_server.start()
         WindowClient.clients.append(self)
 
-    def destory(self):
+    def destroy(self):
         if self in WindowClient.clients:
             WindowClient.clients.remove(self)
         if len(WindowClient.clients) == 0:

--- a/fishy/engine/common/window.py
+++ b/fishy/engine/common/window.py
@@ -83,8 +83,8 @@ class WindowClient:
 
         if func is None:
             return img
-        else:
-            return func(img)
+
+        return func(img)
 
     def show(self, to_show, resize=None, func=None):
         """

--- a/fishy/engine/common/window_server.py
+++ b/fishy/engine/common/window_server.py
@@ -1,17 +1,14 @@
 import logging
 import math
-import traceback
 from enum import Enum
 from threading import Thread
 
-import cv2
 import d3dshot
 import pywintypes
 import win32api
 import win32gui
 from ctypes import windll
 
-from fishy.helper.config import config
 from fishy.helper.helper import print_exc
 
 
@@ -38,6 +35,7 @@ def init():
     Executed once before the main loop,
     Finds the game window, and calculates the offset to remove the title bar
     """
+    # noinspection PyUnresolvedReferences
     try:
         WindowServer.hwnd = win32gui.FindWindow(None, "Elder Scrolls Online")
 

--- a/fishy/engine/common/window_server.py
+++ b/fishy/engine/common/window_server.py
@@ -26,7 +26,7 @@ class WindowServer:
     windowOffset = None
     hwnd = None
     status = Status.STOPPED
-    d3: d3dshot.D3DShot = None
+    d3: d3dshot.D3DShot = d3dshot.create(capture_output="numpy")
     monitor_top_left = None
 
 
@@ -47,9 +47,7 @@ def init():
         WindowServer.windowOffset = math.floor(((rect[2] - rect[0]) - client_rect[2]) / 2)
         WindowServer.status = Status.RUNNING
 
-        d3 = d3dshot.create(capture_output="numpy")
-        d3.display = next((m for m in d3.displays if m.hmonitor == monitor_id), None)
-        WindowServer.d3 = d3
+        WindowServer.d3.display = next((m for m in WindowServer.d3.displays if m.hmonitor == monitor_id), None)
 
     except pywintypes.error:
         logging.error("Game window not found")

--- a/fishy/engine/common/window_server.py
+++ b/fishy/engine/common/window_server.py
@@ -12,6 +12,7 @@ import win32gui
 from ctypes import windll
 
 from fishy.helper.config import config
+from fishy.helper.helper import print_exc
 
 
 class Status(Enum):
@@ -92,7 +93,7 @@ def run():
         try:
             loop()
         except Exception:
-            traceback.print_exc()
+            print_exc()
             WindowServer.status = Status.CRASHED
 
     if WindowServer.status == Status.CRASHED:

--- a/fishy/engine/common/window_server.py
+++ b/fishy/engine/common/window_server.py
@@ -84,20 +84,21 @@ def loop():
         WindowServer.status = Status.CRASHED
 
 
-def loop_end():
-    cv2.waitKey(25)
-
-
 # noinspection PyBroadException
 def run():
     # todo use config
+    logging.debug("window server started")
     while WindowServer.status == Status.RUNNING:
         try:
             loop()
         except Exception:
             traceback.print_exc()
             WindowServer.status = Status.CRASHED
-    loop_end()
+
+    if WindowServer.status == Status.CRASHED:
+        logging.debug("window server crashed")
+    elif WindowServer.status == Status.STOPPED:
+        logging.debug("window server stopped")
 
 
 def start():

--- a/fishy/engine/fullautofisher/controls.py
+++ b/fishy/engine/fullautofisher/controls.py
@@ -4,6 +4,8 @@ from pynput.keyboard import Key
 
 from fishy.helper import hotkey
 
+# todo: unused code remove it
+
 
 def get_controls(controls: 'Controls'):
     controls = [

--- a/fishy/engine/fullautofisher/engine.py
+++ b/fishy/engine/fullautofisher/engine.py
@@ -122,13 +122,13 @@ class FullAuto(IEngine):
         if not current:
             return False
 
-        print(f"Moving from {(current[0], current[1])} to {target}")
+        logging.debug(f"Moving from {(current[0], current[1])} to {target}")
         move_vec = target[0] - current[0], target[1] - current[1]
 
         dist = math.sqrt(move_vec[0] ** 2 + move_vec[1] ** 2)
-        print(f"distance: {dist}")
+        logging.debug(f"distance: {dist}")
         if dist < 5e-05:
-            print("distance very small skipping")
+            logging.debug("distance very small skipping")
             return True
 
         target_angle = math.degrees(math.atan2(-move_vec[1], move_vec[0])) + 90
@@ -138,11 +138,11 @@ class FullAuto(IEngine):
             return False
 
         walking_time = dist / self.calibrator.move_factor
-        print(f"walking for {walking_time}")
+        logging.debug(f"walking for {walking_time}")
         kb.press('w')
         time.sleep(walking_time)
         kb.release('w')
-        print("done")
+        logging.debug("done")
         # todo: maybe check if it reached the destination before returning true?
         return True
 
@@ -157,7 +157,7 @@ class FullAuto(IEngine):
             target_angle = 360 + target_angle
         while target_angle > 360:
             target_angle -= 360
-        print(f"Rotating from {from_angle} to {target_angle}")
+        logging.debug(f"Rotating from {from_angle} to {target_angle}")
 
         angle_diff = target_angle - from_angle
 
@@ -166,7 +166,7 @@ class FullAuto(IEngine):
 
         rotate_times = int(angle_diff / self.calibrator.rot_factor) * -1
 
-        print(f"rotate_times: {rotate_times}")
+        logging.debug(f"rotate_times: {rotate_times}")
 
         for _ in range(abs(rotate_times)):
             mse.move(sign(rotate_times) * FullAuto.rotate_by * -1, 0)

--- a/fishy/engine/fullautofisher/engine.py
+++ b/fishy/engine/fullautofisher/engine.py
@@ -1,10 +1,8 @@
 import logging
 import math
 import time
-import traceback
 from threading import Thread
 
-import cv2
 from pynput import keyboard, mouse
 
 from fishy.engine import SemiFisherEngine
@@ -16,9 +14,8 @@ from fishy.engine.fullautofisher.mode.player import Player
 from fishy.engine.fullautofisher.mode.recorder import Recorder
 from fishy.engine.common.qr_detection import (get_qr_location,
                                               get_values_from_image, image_pre_process)
-from fishy.engine.semifisher import fishing_event, fishing_mode
+from fishy.engine.semifisher import fishing_mode
 from fishy.engine.semifisher.fishing_mode import FishingMode
-from fishy.helper import hotkey
 from fishy.helper.config import config
 from fishy.helper.helper import wait_until, is_eso_active, sign, print_exc
 
@@ -201,8 +198,6 @@ class FullAuto(IEngine):
 
 
 if __name__ == '__main__':
-    logging.getLogger("").setLevel(logging.DEBUG)
-    hotkey.initalize()
     # noinspection PyTypeChecker
     bot = FullAuto(None)
     bot.toggle_start()

--- a/fishy/engine/fullautofisher/engine.py
+++ b/fishy/engine/fullautofisher/engine.py
@@ -43,8 +43,6 @@ class FullAuto(IEngine):
         self.mode = None
 
     def run(self):
-        self.window = WindowClient(color=cv2.COLOR_RGB2GRAY, show_name="Full auto debug")
-
         self.mode = None
         if config.get("calibrate", False):
             self.mode = Calibrator(self)
@@ -198,12 +196,6 @@ class FullAuto(IEngine):
             mse.move(0, -FullAuto.rotate_by)
             time.sleep(0.05)
             self._curr_rotate_y -= 0.05
-
-    def toggle_start(self):
-        self.start = not self.start
-        if self.start:
-            self.thread = Thread(target=self.run)
-            self.thread.start()
 
 
 if __name__ == '__main__':

--- a/fishy/engine/fullautofisher/engine.py
+++ b/fishy/engine/fullautofisher/engine.py
@@ -30,6 +30,7 @@ class FullAuto(IEngine):
         from fishy.engine.fullautofisher.test import Test
 
         super().__init__(gui_ref)
+        self.name = "FullAuto"
         self._curr_rotate_y = 0
 
         self.fisher = SemiFisherEngine(None)

--- a/fishy/engine/fullautofisher/mode/calibrator.py
+++ b/fishy/engine/fullautofisher/mode/calibrator.py
@@ -20,7 +20,7 @@ kb = keyboard.Controller()
 offset = 0
 
 
-def get_crop_coods(window):
+def get_crop_coords(window):
     img = window.get_capture()
     img = cv2.inRange(img, 0, 1)
 
@@ -36,6 +36,8 @@ def get_crop_coods(window):
             cv2.drawContours(mask, cnt, i, 255, -1)
             x, y, w, h = cv2.boundingRect(cnt[i])
             return x, y + offset, x + w, y + h - offset
+
+    return None
 
 
 def _update_factor(key, value):

--- a/fishy/engine/fullautofisher/mode/calibrator.py
+++ b/fishy/engine/fullautofisher/mode/calibrator.py
@@ -75,25 +75,25 @@ class Calibrator(IMode):
     def _walk_calibrate(self):
         walking_time = 3
 
-        coods = self.engine.get_coords()
-        if coods is None:
+        coords = self.engine.get_coords()
+        if coords is None:
             return
 
-        x1, y1, rot1 = coods
+        x1, y1, rot1 = coords
 
         kb.press('w')
         time.sleep(walking_time)
         kb.release('w')
         time.sleep(0.5)
 
-        coods = self.engine.get_coords()
-        if coods is None:
+        coords = self.engine.get_coords()
+        if coords is None:
             return
-        x2, y2, rot2 = coods
+        x2, y2, rot2 = coords
 
         move_factor = math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2) / walking_time
         _update_factor("move_factor", move_factor)
-        logging.info("walk calibrate done")
+        logging.info(f"walk calibrate done, move_factor: {move_factor}")
 
     def _rotate_calibrate(self):
         from fishy.engine.fullautofisher.engine import FullAuto
@@ -119,7 +119,7 @@ class Calibrator(IMode):
 
         rot_factor = (rot3 - rot2) / rotate_times
         _update_factor("rot_factor", rot_factor)
-        logging.info("rotate calibrate done")
+        logging.info(f"rotate calibrate done, rot_factor: {rot_factor}")
 
     def run(self):
         self._walk_calibrate()

--- a/fishy/engine/fullautofisher/mode/player.py
+++ b/fishy/engine/fullautofisher/mode/player.py
@@ -75,6 +75,7 @@ class Player(IMode):
 
         self.i = find_nearest(self.timeline, coords)[0]
         logging.info("starting player")
+        return True
 
     def _loop(self):
         action = self.timeline[self.i]

--- a/fishy/engine/fullautofisher/mode/player.py
+++ b/fishy/engine/fullautofisher/mode/player.py
@@ -2,14 +2,11 @@ import logging
 import math
 import pickle
 import time
-from pprint import pprint
 
 import typing
-from threading import Thread
 
 from fishy.engine.fullautofisher.mode.imode import IMode
 from fishy.engine.semifisher import fishing_event, fishing_mode
-from fishy.helper.helper import log_raise, wait_until, kill_thread
 
 if typing.TYPE_CHECKING:
     from fishy.engine.fullautofisher.engine import FullAuto
@@ -56,23 +53,28 @@ class Player(IMode):
         self.timeline = None
 
     def run(self):
-        self._init()
+        if not self._init():
+            return
+
         while self.engine.start:
             self._loop()
             time.sleep(0.1)
+
         logging.info("player stopped")
 
-    def _init(self):
+    def _init(self) -> bool:
         self.timeline = get_rec_file()
         if not self.timeline:
-            log_raise("data not found, can't start")
-        logging.info("starting player")
+            logging.error("data not found, can't start")
+            return False
 
         coords = self.engine.get_coords()
         if not coords:
-            log_raise("QR not found")
+            logging.error("QR not found")
+            return False
 
         self.i = find_nearest(self.timeline, coords)[0]
+        logging.info("starting player")
 
     def _loop(self):
         action = self.timeline[self.i]
@@ -87,21 +89,22 @@ class Player(IMode):
             if not self.engine.rotate_to(action[1][2]):
                 return
 
-            fishing_mode.subscribers.append(self._hole_complete_callback)
-            fishing_event.subscribe()
+            self.engine.fisher.turn_on()
             # scan for fish hole
             logging.info("scanning")
             # if found start fishing and wait for hole to complete
             if self.engine.look_for_hole():
                 logging.info("starting fishing")
+                fishing_mode.subscribers.append(self._hole_complete_callback)
                 self.hole_complete_flag = False
                 helper.wait_until(lambda: self.hole_complete_flag or not self.engine.start)
+                fishing_mode.subscribers.remove(self._hole_complete_callback)
+
                 self.engine.rotate_back()
             else:
                 logging.info("no hole found")
             # continue when hole completes
-            fishing_mode.subscribers.remove(self._hole_complete_callback)
-            fishing_event.unsubscribe()
+            self.engine.fisher.turn_off()
 
         self.next()
 

--- a/fishy/engine/fullautofisher/test.py
+++ b/fishy/engine/fullautofisher/test.py
@@ -9,7 +9,7 @@ class Test:
         self.target = None
 
     # noinspection PyProtectedMember
-    def print_coods(self):
+    def print_coords(self):
         logging.info(self.engine.get_coords())
 
     def set_target(self):

--- a/fishy/engine/semifisher/engine.py
+++ b/fishy/engine/semifisher/engine.py
@@ -1,6 +1,5 @@
 import logging
 import time
-import traceback
 import typing
 from threading import Thread
 from typing import Callable, Optional

--- a/fishy/engine/semifisher/engine.py
+++ b/fishy/engine/semifisher/engine.py
@@ -21,6 +21,7 @@ class SemiFisherEngine(IEngine):
     def __init__(self, gui_ref: Optional['Callable[[], GUI]']):
         super().__init__(gui_ref)
         self.window = None
+        self.name = "SemiFisher"
 
     def run(self):
         """

--- a/fishy/engine/semifisher/fishing_event.py
+++ b/fishy/engine/semifisher/fishing_event.py
@@ -78,9 +78,6 @@ def subscribe():
     if fisher_callback not in fishing_mode.subscribers:
         fishing_mode.subscribers.append(fisher_callback)
 
-        if FishingMode.CurrentMode == State.LOOKING:
-            fisher_callback(FishingMode.CurrentMode)
-
 
 def fisher_callback(event: State):
     callbacks_map = {

--- a/fishy/gui/config_top.py
+++ b/fishy/gui/config_top.py
@@ -2,20 +2,15 @@ import logging
 import os
 import tkinter as tk
 import tkinter.ttk as ttk
-import typing
 from tkinter.filedialog import askopenfilename
 
 from fishy.engine.common.event_handler import IEngineHandler
 from fishy.engine.fullautofisher.mode.imode import FullAutoMode
-from fishy.helper import helper
 
 from fishy import web
 from fishy.helper import helper
 from fishy.helper.config import config
 from fishy.helper.popup import PopUp
-
-if typing.TYPE_CHECKING:
-    from fishy.gui import GUI
 
 
 def start_fullfisher_config(gui: 'GUI'):

--- a/fishy/gui/discord_login.py
+++ b/fishy/gui/discord_login.py
@@ -26,6 +26,7 @@ def discord_login(gui: 'GUI'):
         top.destroy()
         top_running[0] = False
 
+    # noinspection PyUnresolvedReferences
     def check():
         code = int(login_code.get()) if login_code.get().isdigit() else 0
         if web.login(config.get("uid"), code):

--- a/fishy/gui/gui.py
+++ b/fishy/gui/gui.py
@@ -8,10 +8,9 @@ from dataclasses import dataclass
 
 from ttkthemes import ThemedTk
 
-from fishy.engine.common.event_handler import EngineEventHandler, IEngineHandler
+from fishy.engine.common.event_handler import IEngineHandler
 from fishy.gui import config_top
 from fishy.gui.funcs import GUIFuncs
-from fishy.web import web
 
 from ..helper.config import config
 from ..helper.helper import wait_until

--- a/fishy/gui/gui.py
+++ b/fishy/gui/gui.py
@@ -1,4 +1,3 @@
-import logging
 import queue
 import threading
 import tkinter as tk
@@ -15,7 +14,6 @@ from fishy.gui.funcs import GUIFuncs
 from ..helper.config import config
 from ..helper.helper import wait_until
 from . import main_gui
-from .log_config import GuiLogger
 
 
 @dataclass

--- a/fishy/gui/gui.py
+++ b/fishy/gui/gui.py
@@ -15,7 +15,7 @@ from fishy.gui.funcs import GUIFuncs
 from ..helper.config import config
 from ..helper.helper import wait_until
 from . import main_gui
-from .log_config import GUIStreamHandler
+from .log_config import GuiLogger
 
 
 @dataclass
@@ -51,12 +51,6 @@ class GUI:
 
         self._notify = None
         self.login = None
-
-        root_logger = logging.getLogger('')
-        root_logger.setLevel(logging.DEBUG)
-        logging.getLogger('urllib3').setLevel(logging.WARNING)
-        new_console = GUIStreamHandler(self)
-        root_logger.addHandler(new_console)
 
     @property
     def engine(self):
@@ -99,3 +93,17 @@ class GUI:
 
     def _get_start_stop_text(self):
         return "STOP (F9)" if self._bot_running else "START (F9)"
+
+    def write_to_console(self, msg):
+        if not self._console:
+            return
+
+        numlines = self._console.index('end - 1 line').split('.')[0]
+        self._console['state'] = 'normal'
+        if int(numlines) >= 50:  # delete old lines
+            self._console.delete(1.0, 2.0)
+        if self._console.index('end-1c') != '1.0':  # new line for each log
+            self._console.insert('end', '\n')
+        self._console.insert('end', msg)
+        self._console.see("end")  # scroll to bottom
+        self._console['state'] = 'disabled'

--- a/fishy/gui/gui.py
+++ b/fishy/gui/gui.py
@@ -25,9 +25,10 @@ class EngineRunner:
 
 
 class GUI:
-    def __init__(self, get_engine: Callable[[], IEngineHandler]):
+    def __init__(self, get_engine: Callable[[], IEngineHandler], on_ready: Callable):
         self.funcs = GUIFuncs(self)
         self.get_engine = get_engine
+        self.on_ready = on_ready
 
         self.config = config
         self._start_restart = False

--- a/fishy/gui/log_config.py
+++ b/fishy/gui/log_config.py
@@ -12,7 +12,6 @@ class GUIStreamHandler(StreamHandler):
         self.gui = gui
 
     def emit(self, record):
-        self.setLevel(logging.INFO)
         msg = self.format(record)
         self.gui.call_in_thread(lambda: _write_to_console(self.gui, msg))
 

--- a/fishy/gui/log_config.py
+++ b/fishy/gui/log_config.py
@@ -12,6 +12,9 @@ class GUIStreamHandler(StreamHandler):
         self.gui = gui
 
     def emit(self, record):
+        # todo implement verbose/debug option to show more info
+        # formatter = Formatter('%(name)s - %(levelname)s - %(message)s')
+        # self.setFormatter(formatter)
         msg = self.format(record)
         self.gui.call_in_thread(lambda: _write_to_console(self.gui, msg))
 

--- a/fishy/gui/log_config.py
+++ b/fishy/gui/log_config.py
@@ -2,6 +2,8 @@ import logging
 import typing
 from logging import StreamHandler, Formatter
 
+from fishy.helper.config import config
+
 if typing.TYPE_CHECKING:
     from . import GUI
 
@@ -12,9 +14,9 @@ class GUIStreamHandler(StreamHandler):
         self.gui = gui
 
     def emit(self, record):
-        # todo implement verbose/debug option to show more info
-        # formatter = Formatter('%(name)s - %(levelname)s - %(message)s')
-        # self.setFormatter(formatter)
+        formatter = Formatter('%(levelname)s - %(message)s')
+        self.setFormatter(formatter)
+        self.setLevel(logging.DEBUG if config.get("debug", False) else logging.INFO)
         msg = self.format(record)
         self.gui.call_in_thread(lambda: _write_to_console(self.gui, msg))
 

--- a/fishy/gui/main_gui.py
+++ b/fishy/gui/main_gui.py
@@ -10,7 +10,7 @@ from ttkthemes import ThemedTk
 from fishy import helper
 from fishy.web import web
 
-from ..constants import chalutier, lam2, fishyqr
+from ..constants import fishyqr
 from ..helper.config import config
 from .discord_login import discord_login
 from ..helper.hotkey.hotkey_process import hotkey
@@ -131,7 +131,7 @@ def _create(gui: 'GUI'):
 
     hotkey.hook(Key.F9, gui.funcs.start_engine)
 
-    # noinspection PyProtectedMember
+    # noinspection PyProtectedMember,PyUnresolvedReferences
     def set_destroy():
         if gui._bot_running:
             if not tk.messagebox.askyesno(title="Quit?", message="Bot engine running. Quit Anyway?"):

--- a/fishy/gui/main_gui.py
+++ b/fishy/gui/main_gui.py
@@ -139,10 +139,11 @@ def _create(gui: 'GUI'):
 
     gui._root.protocol("WM_DELETE_WINDOW", set_destroy)
     gui._destroyed = False
-    gui._root.update()
-    gui.on_ready()
-    gui._root.after(0, gui._root.attributes, "-alpha", 1.0)
 
+    gui._root.update()
+    gui._clear_function_queue()
+    gui._root.after(0, gui._root.attributes, "-alpha", 1.0)
+    gui.on_ready()
     while True:
         gui._root.update()
         gui._clear_function_queue()
@@ -152,6 +153,6 @@ def _create(gui: 'GUI'):
             gui._start_restart = False
             gui.create()
         if gui._destroyed:
-            gui.engine.quit()
+            gui.engine.quit_me()
             break
         time.sleep(0.01)

--- a/fishy/gui/main_gui.py
+++ b/fishy/gui/main_gui.py
@@ -31,6 +31,7 @@ def _create(gui: 'GUI'):
     engines = gui.engines
 
     gui._root = ThemedTk(theme="equilux", background=True)
+    gui._root.attributes('-alpha', 0.0)
     gui._root.title("Fishybot for Elder Scrolls Online")
     gui._root.iconbitmap(helper.manifest_file('icon.ico'))
 
@@ -138,6 +139,9 @@ def _create(gui: 'GUI'):
 
     gui._root.protocol("WM_DELETE_WINDOW", set_destroy)
     gui._destroyed = False
+    gui._root.update()
+    gui.on_ready()
+    gui._root.after(0, gui._root.attributes, "-alpha", 1.0)
 
     while True:
         gui._root.update()

--- a/fishy/gui/main_gui.py
+++ b/fishy/gui/main_gui.py
@@ -57,7 +57,7 @@ def _create(gui: 'GUI'):
     filemenu.add_checkbutton(label="Dark Mode", command=_toggle_mode,
                              variable=dark_mode_var)
     if config.get("dont_ask_update", False):
-        filemenu.add_command(label="Update", command=helper.update)
+        filemenu.add_command(label="Update", command=lambda: helper.update(gui))
 
     def installer():
         if filemenu.entrycget(4, 'label') == "Remove FishyQR":
@@ -82,7 +82,6 @@ def _create(gui: 'GUI'):
         logging.debug("Restart to update the changes")
 
     debug_menu.add_checkbutton(label="Keep Console", command=keep_console, variable=debug_var)
-    debug_menu.add_command(label="Restart", command=helper.restart)
     menubar.add_cascade(label="Debug", menu=debug_menu)
 
     help_menu = tk.Menu(menubar, tearoff=0)

--- a/fishy/gui/main_gui.py
+++ b/fishy/gui/main_gui.py
@@ -4,6 +4,7 @@ import tkinter as tk
 import tkinter.ttk as ttk
 import typing
 
+from fishy.gui import update_dialog
 from ttkthemes import ThemedTk
 
 from fishy import helper
@@ -56,8 +57,11 @@ def _create(gui: 'GUI'):
     dark_mode_var.set(int(config.get('dark_mode', True)))
     filemenu.add_checkbutton(label="Dark Mode", command=_toggle_mode,
                              variable=dark_mode_var)
-    if config.get("dont_ask_update", False):
-        filemenu.add_command(label="Update", command=lambda: helper.update(gui))
+
+    def update():
+        config.delete("dont_ask_update")
+        update_dialog.check_update(gui, True)
+    filemenu.add_command(label="Update", command=update)
 
     def installer():
         if filemenu.entrycget(4, 'label') == "Remove FishyQR":

--- a/fishy/gui/splash.py
+++ b/fishy/gui/splash.py
@@ -2,6 +2,7 @@ import logging
 import time
 import tkinter as tk
 from multiprocessing import Process, Queue
+from threading import Thread
 
 from PIL import Image, ImageTk
 
@@ -34,9 +35,17 @@ def show(win_loc, q):
     loc = (win_loc or default_loc).split("+")[1:]
     top.geometry("{}x{}+{}+{}".format(dim[0], dim[1], int(loc[0]) + int(dim[0] / 2), int(loc[1]) + int(dim[1] / 2)))
 
-    top.update()
-    q.get()
-    time.sleep(0.2)
+    def waiting():
+        q.get()
+        time.sleep(0.2)
+        running[0] = False
+    Thread(target=waiting).start()
+
+    running = [True]
+    while running[0]:
+        top.update()
+        time.sleep(0.1)
+
     top.destroy()
     logging.debug("ended splash process")
 

--- a/fishy/gui/update_dialog.py
+++ b/fishy/gui/update_dialog.py
@@ -43,8 +43,10 @@ def _show(gui, currentversion, newversion, returns):
     top.start()
 
 
-def check_update(gui):
+def check_update(gui, manual_check=False):
     if not auto_update.upgrade_avail() or config.get("dont_ask_update", False):
+        if manual_check:
+            logging.info("No update is available.")
         return
 
     cv, hv = auto_update.versions()

--- a/fishy/gui/update_dialog.py
+++ b/fishy/gui/update_dialog.py
@@ -1,11 +1,22 @@
+import logging
 import tkinter as tk
-from multiprocessing import Manager, Process
 
-from fishy import helper
+from fishy.helper import helper, auto_update
+from fishy.helper.config import config
+from fishy.helper.popup import PopUp
 
 
-def show(currentversion, newversion, returns):
-    top = tk.Tk()
+def _show(gui, currentversion, newversion, returns):
+
+    def _clickYes():
+        returns[0], returns[1] = True, False
+        top.quit_top()
+
+    def _clickNo():
+        returns[0], returns[1] = False, bool(cbVar.get())
+        top.quit_top()
+
+    top = PopUp(helper.empty_function, gui._root)
     top.title("A wild fishy update appeared!")
     top.iconbitmap(helper.manifest_file('icon.ico'))
 
@@ -19,14 +30,6 @@ def show(currentversion, newversion, returns):
     top.update()
     buttonWidth = int(dialogLabel.winfo_width() / 2) - 20
 
-    def _clickYes():
-        returns[0], returns[1] = True, False
-        top.destroy()
-
-    def _clickNo():
-        returns[0], returns[1] = False, bool(cbVar.get())
-        top.destroy()
-
     pixelVirtual = tk.PhotoImage(width=1, height=1)  # trick to use buttonWidth as pixels, not #symbols
     dialogBtnNo = tk.Button(top, text="No " + str(chr(10005)), fg='red4', command=_clickNo, image=pixelVirtual,
                             width=buttonWidth, compound="c")
@@ -37,14 +40,21 @@ def show(currentversion, newversion, returns):
     dialogBtnYes.focus_set()
 
     top.protocol('WM_DELETE_WINDOW', _clickNo)
-
-    top.update()
-    top.mainloop()
+    top.start()
 
 
-def start(currentversion, newversion):
-    returns = Manager().dict()
-    p = Process(target=show, args=(currentversion, newversion, returns))
-    p.start()
-    p.join()
-    return returns[0], returns[1]
+def check_update(gui):
+    if not auto_update.upgrade_avail() or config.get("dont_ask_update", False):
+        return
+
+    cv, hv = auto_update.versions()
+    returns = [None, None]
+    _show(gui, cv, hv, returns)
+    [update_now, dont_ask_update] = returns
+    if dont_ask_update:
+        config.set("dont_ask_update", dont_ask_update)
+    else:
+        config.delete("dont_ask_update")
+
+    if update_now:
+        gui.engine.set_update(hv)

--- a/fishy/helper/__init__.py
+++ b/fishy/helper/__init__.py
@@ -1,8 +1,8 @@
 from .config import Config
 from .helper import (addon_exists, create_shortcut, create_shortcut_first,
-                     get_addonversion, get_savedvarsdir, initialize_uid,
+                     get_addonversion, get_savedvarsdir,
                      install_addon, install_thread_excepthook, manifest_file,
                      not_implemented, open_web, playsound_multiple,
-                     remove_addon, restart, unhandled_exception_logging,
+                     remove_addon, unhandled_exception_logging,
                      update, install_required_addons)
 from .luaparser import sv_color_extract

--- a/fishy/helper/__init__.py
+++ b/fishy/helper/__init__.py
@@ -4,5 +4,5 @@ from .helper import (addon_exists, create_shortcut, create_shortcut_first,
                      install_addon, install_thread_excepthook, manifest_file,
                      not_implemented, open_web, playsound_multiple,
                      remove_addon, unhandled_exception_logging,
-                     update, install_required_addons)
+                     install_required_addons)
 from .luaparser import sv_color_extract

--- a/fishy/helper/__init__.py
+++ b/fishy/helper/__init__.py
@@ -1,4 +1,3 @@
-from .auto_update import auto_upgrade, upgrade_avail, versions
 from .config import Config
 from .helper import (addon_exists, create_shortcut, create_shortcut_first,
                      get_addonversion, get_savedvarsdir, initialize_uid,

--- a/fishy/helper/active_poll.py
+++ b/fishy/helper/active_poll.py
@@ -1,3 +1,5 @@
+import logging
+
 from event_scheduler import EventScheduler
 from fishy.web import web
 
@@ -13,11 +15,14 @@ class active:
 
         active._scheduler = EventScheduler()
         active._scheduler.start()
+        logging.debug("active scheduler initialized")
 
     @staticmethod
     def start():
         active._scheduler.enter_recurring(60, 1, web.ping)
+        logging.debug("active scheduler started")
 
     @staticmethod
     def stop():
         active._scheduler.stop(hard_stop=True)
+        logging.debug("active scheduler stopped")

--- a/fishy/helper/auto_update.py
+++ b/fishy/helper/auto_update.py
@@ -88,13 +88,12 @@ def upgrade_avail():
     return _get_current_version() < _get_highest_version(index, pkg)
 
 
-def auto_upgrade():
+def update_now(version):
     """
     public function,
     compares current version with the latest version (from web),
     if current version is older, then it updates and restarts the script
     """
-    version = _hr_version(_get_highest_version(index, pkg))
     logging.info(f"Updating to v{version}, Please Wait...")
     subprocess.call(["python", '-m', 'pip', 'install', '--upgrade', 'fishy', '--user'])
     execl(sys.executable, *([sys.executable, '-m', 'fishy'] + sys.argv[1:]))

--- a/fishy/helper/auto_update.py
+++ b/fishy/helper/auto_update.py
@@ -38,29 +38,29 @@ def _normalize_version(v):
     return rv
 
 
-def _get_highest_version(index, pkg):
+def _get_highest_version(_index, _pkg):
     """
     Crawls web for latest version name then returns latest version
-    :param index: website to check
-    :param pkg: package name
+    :param _index: website to check
+    :param _pkg: package name
     :return: latest version normalized
     """
-    url = "{}/{}/".format(index, pkg)
+    url = "{}/{}/".format(_index, _pkg)
     html = urllib.request.urlopen(url)
     if html.getcode() != 200:
         raise Exception  # not found
     soup = BeautifulSoup(html.read(), "html.parser")
-    versions = []
+    _versions = []
     for link in soup.find_all('a'):
         text = link.get_text()
         try:
-            version = re.search(pkg + r'-(.*)\.tar\.gz', text).group(1)
-            versions.append(_normalize_version(version))
+            version = re.search(_pkg + r'-(.*)\.tar\.gz', text).group(1)
+            _versions.append(_normalize_version(version))
         except AttributeError:
             pass
-    if len(versions) == 0:
+    if len(_versions) == 0:
         raise Exception  # no version
-    return max(versions)
+    return max(_versions)
 
 
 def _get_current_version():

--- a/fishy/helper/config.py
+++ b/fishy/helper/config.py
@@ -3,6 +3,7 @@ config.py
 Saves configuration in file as json file
 """
 import json
+import logging
 import os
 # path to save the configuration file
 from typing import Optional
@@ -46,17 +47,18 @@ class Config:
                 self._config_dict = json.loads(open(filename()).read())
             except json.JSONDecodeError:
                 try:
-                    print("Config file got corrupted, trying to restore backup")
+                    logging.warning("Config file got corrupted, trying to restore backup")
                     self._config_dict = json.loads(open(temp_file).read())
                     self.save_config()
                 except (FileNotFoundError, json.JSONDecodeError):
-                    print("couldn't restore, creating new")
+                    logging.warning("couldn't restore, creating new")
                     os.remove(filename())
                     self._config_dict = dict()
 
         else:
             self._config_dict = dict()
 
+    def start_backup_scheduler(self):
         self._create_backup()
         self._scheduler.start()
         self._scheduler.enter_recurring(5 * 60, 1, self._create_backup)
@@ -67,7 +69,7 @@ class Config:
     def _create_backup(self):
         with open(temp_file, 'w') as f:
             f.write(json.dumps(self._config_dict))
-        print("created backup")
+        logging.debug("created backup")
 
     def _sort_dict(self):
         tmpdict = dict()
@@ -92,6 +94,10 @@ class config:
     def init():
         config._instance = Config()
         config._instance.initialize()
+
+    @staticmethod
+    def start_backup_scheduler():
+        config._instance.start_backup_scheduler()
 
     @staticmethod
     def stop():

--- a/fishy/helper/config.py
+++ b/fishy/helper/config.py
@@ -57,14 +57,17 @@ class Config:
 
         else:
             self._config_dict = dict()
+        logging.debug("config initialized")
 
     def start_backup_scheduler(self):
         self._create_backup()
         self._scheduler.start()
         self._scheduler.enter_recurring(5 * 60, 1, self._create_backup)
+        logging.debug("scheduler started")
 
     def stop(self):
         self._scheduler.stop(True)
+        logging.debug("config stopped")
 
     def _create_backup(self):
         with open(temp_file, 'w') as f:

--- a/fishy/helper/config.py
+++ b/fishy/helper/config.py
@@ -92,8 +92,9 @@ class config:
 
     @staticmethod
     def init():
-        config._instance = Config()
-        config._instance.initialize()
+        if not config._instance:
+            config._instance = Config()
+            config._instance.initialize()
 
     @staticmethod
     def start_backup_scheduler():

--- a/fishy/helper/helper.py
+++ b/fishy/helper/helper.py
@@ -15,14 +15,12 @@ from zipfile import ZipFile
 
 import requests
 import winshell
-from fishy.gui import update_dialog
 from playsound import playsound
 from win32com.client import Dispatch
 from win32comext.shell import shell, shellcon
 from win32gui import GetForegroundWindow, GetWindowText
 
 import fishy
-from fishy import web
 from fishy.constants import libgps, lam2, fishyqr
 from fishy.helper.config import config
 
@@ -129,8 +127,8 @@ def create_shortcut(anti_ghosting: bool):
         desktop = winshell.desktop()
         path = os.path.join(desktop, "Fishybot ESO.lnk")
 
-        shell = Dispatch('WScript.Shell')
-        shortcut = shell.CreateShortCut(path)
+        _shell = Dispatch('WScript.Shell')
+        shortcut = _shell.CreateShortCut(path)
 
         if anti_ghosting:
             shortcut.TargetPath = r"C:\Windows\System32\cmd.exe"
@@ -170,6 +168,7 @@ def addon_exists(name, url=None, v=None):
 def get_addonversion(name, url=None, v=None):
     if addon_exists(name):
         txt = name + ".txt"
+        # noinspection PyBroadException
         try:
             with open(os.path.join(get_addondir(), name, txt)) as f:
                 for line in f:
@@ -241,9 +240,9 @@ def _get_id(thread):
     # returns id of the respective thread
     if hasattr(thread, '_thread_id'):
         return thread._thread_id
-    for id, thread in threading._active.items():
+    for _id, thread in threading._active.items():
         if thread is thread:
-            return id
+            return _id
 
 
 def kill_thread(thread):

--- a/fishy/helper/helper.py
+++ b/fishy/helper/helper.py
@@ -15,6 +15,7 @@ from zipfile import ZipFile
 
 import requests
 import winshell
+from fishy.gui import update_dialog
 from playsound import playsound
 from win32com.client import Dispatch
 from win32comext.shell import shell, shellcon
@@ -64,19 +65,6 @@ def open_web(website):
     """
     logging.debug("opening web, please wait...")
     Thread(target=lambda: webbrowser.open(website, new=2)).start()
-
-
-def initialize_uid():
-    from .config import config
-
-    if config.get("uid") is not None:
-        return
-
-    new_uid = web.register_user()
-    if new_uid is not None:
-        config.set("uid", new_uid)
-    else:
-        logging.error("Couldn't register uid, some features might not work")
 
 
 def _create_new_uid():
@@ -239,20 +227,16 @@ def get_documents():
     return shell.SHGetFolderPath(0, shellcon.CSIDL_PERSONAL, None, 0)
 
 
-def restart():
-    os.execl(sys.executable, *([sys.executable] + sys.argv))
-
-
 def log_raise(msg):
     logging.error(msg)
     raise Exception(msg)
 
 
-def update():
+def update(gui):
     from .config import config
 
     config.delete("dont_ask_update")
-    restart()
+    update_dialog.check_update(gui)
 
 
 def is_eso_active():

--- a/fishy/helper/helper.py
+++ b/fishy/helper/helper.py
@@ -157,7 +157,7 @@ def create_shortcut(anti_ghosting: bool):
 
         logging.info("Shortcut created")
     except Exception:
-        traceback.print_exc()
+        print_exc()
         logging.error("Couldn't create shortcut")
 
 
@@ -219,7 +219,7 @@ def install_addon(name, url, v=None):
         return 0
     except Exception:
         logging.error("Could not install Add-On " + name + ", try doing it manually")
-        traceback.print_exc()
+        print_exc()
         return 1
 
 
@@ -276,3 +276,8 @@ def kill_thread(thread):
     if res > 1:
         ctypes.pythonapi.PyThreadState_SetAsyncExc(thread_id, 0)
         print('Exception raise failure')
+        
+        
+def print_exc():
+    logging.error(traceback.format_exc())
+    traceback.print_exc()

--- a/fishy/helper/helper.py
+++ b/fishy/helper/helper.py
@@ -232,13 +232,6 @@ def log_raise(msg):
     raise Exception(msg)
 
 
-def update(gui):
-    from .config import config
-
-    config.delete("dont_ask_update")
-    update_dialog.check_update(gui)
-
-
 def is_eso_active():
     return GetWindowText(GetForegroundWindow()) == "Elder Scrolls Online"
 

--- a/fishy/helper/hotkey/hotkey_process.py
+++ b/fishy/helper/hotkey/hotkey_process.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from multiprocessing import Process, Queue
 from threading import Thread
@@ -69,10 +70,11 @@ class HotKey:
     def start(self):
         self.process.start()
         self.event.start()
+        logging.debug("hotkey process started")
 
     def stop(self):
         self.inq.put("stop")
         self.outq.put("stop")
         self.process.join()
         self.event.join()
-        print("hotkey process ended")
+        logging.debug("hotkey process ended")

--- a/fishy/helper/migration.py
+++ b/fishy/helper/migration.py
@@ -2,8 +2,7 @@ import logging
 
 from fishy.helper.auto_update import _normalize_version
 
-from fishy.constants import chalutier, version
-from fishy.helper import helper
+from fishy.constants import version
 from .config import config
 
 

--- a/fishy/helper/popup.py
+++ b/fishy/helper/popup.py
@@ -19,6 +19,7 @@ class PopUp(Toplevel):
         super().__init__(*args, **kwargs)
         self.running = True
         self.quit_callback = quit_callback
+        self.protocol("WM_DELETE_WINDOW", self.quit_top)
 
     def quit_top(self):
         self.quit_callback()
@@ -26,7 +27,6 @@ class PopUp(Toplevel):
         self.running = False
 
     def start(self):
-        self.protocol("WM_DELETE_WINDOW", self.quit_top)
         self.grab_set()
         center(self)
         while self.running:

--- a/fishy/web/web.py
+++ b/fishy/web/web.py
@@ -1,3 +1,5 @@
+import logging
+
 import requests
 from whatsmyip.ip import get_ip
 from whatsmyip.providers import GoogleDnsProvider
@@ -112,24 +114,48 @@ def unsub():
     return result["success"]
 
 
-@fallback(None)
 def get_session(lazy=True):
     global _session_id
 
+    # lazy loading logic
     if lazy and _session_id is not None:
         return _session_id
 
-    body = {"uid": config.get("uid"), "apiversion": apiversion}
+    # check if user has uid
+    uid = config.get("uid")
+
+    # then create session
+    if uid:
+        _session_id, online = _create_new_session(uid)
+    # if not, create new id then try creating session again
+    else:
+        uid = register_user()
+        logging.debug("New User, generated new uid")
+        if uid:
+            _session_id, online = _create_new_session(uid)
+        else:
+            online = False
+
+    # when the user is already registered but session is not created as uid is not found
+    if online and not _session_id:
+        logging.error("user not found, generating new uid.. contact dev if you don't want to loose data")
+        new_uid = register_user()
+        _session_id, online = _create_new_session(new_uid)
+        config.set("uid", new_uid)
+        config.set("old_uid", uid)
+
+    return _session_id
+
+
+@fallback((None, False))
+def _create_new_session(uid):
+    body = {"uid": uid, "apiversion": apiversion}
     response = requests.post(urls.session, params=body)
 
     if response.status_code == 405:
-        config.delete("uid")
-        helper.restart()
-        return None
+        return None, True
 
-    _session_id = response.json()["session_id"]
-    return _session_id
-
+    return response.json()["session_id"], True
 
 @fallback(False)
 def has_beta():

--- a/fishy/web/web.py
+++ b/fishy/web/web.py
@@ -4,8 +4,6 @@ import requests
 from whatsmyip.ip import get_ip
 from whatsmyip.providers import GoogleDnsProvider
 
-from fishy import helper
-
 from ..constants import apiversion
 from ..helper.config import config
 from . import urls
@@ -88,8 +86,6 @@ def sub():
 @fallback((False, False))
 def is_subbed():
     """
-    :param uid:
-    :param lazy:
     :return: Tuple[is_subbed, success]
     """
 
@@ -102,8 +98,8 @@ def is_subbed():
     if response.status_code != 200:
         return False, False
 
-    is_subbed = response.json()["subbed"]
-    return is_subbed, True
+    _is_subbed = response.json()["subbed"]
+    return _is_subbed, True
 
 
 @fallback(None)


### PR DESCRIPTION
#### Objectives of this PR
- To make fishy safely exit without leaving any orphan thread/process in any scenario
- For exceptions to occur only when something goes wrong (instead of using it for control flow)

#### Exception:
- When update is started from within fishy, it needs to restart the application, which is done using "execl" function. That function is  the last thing which is ran when that situation arrises, so that fishy does everything it wants to exit safely, before it restart.

#### Features added:
- splash screen now waits for fishy to start
instead of waiting 3 (arbitrary) seconds, it waits for a message from gui thread before it safely exists

- update popup now shows after fishy starts https://github.com/fishyboteso/fishyboteso/issues/42
doing this also removed an extra Process just for that one popup, now its runs from gui thread just like config popups

- logging, added alot of debug log messages, which shows up only when fishy is ran in debug mode

Changes needed to be made:
- EULA now comes up before anything else https://github.com/fishyboteso/fishyboteso/issues/71
declining eula was leaving orphan threads, so fishy now waits for eula process to complete before initializing anything else

#### Few features needed to be removed:

- prompt before quiting fishy when any engine is running
As engine now exits safely when the bot is closed, the prompt never shows up as the check occurs after engine exits. Even though the feature is remained untouched, it doesn't show up as a side effect of the improvement

- `debug > restart` option
Restart kills fishy process to start a new one, which direct goes against the philosophy of this PR

- removed double beep on turnoff
the same beep sfx is being used for hotkey and engine on/off which made it really confusing, so for now beep is only used to give feedback for hotkey and is removed from engine

- hide "update" option in file menu if "dont ask" option is not checked in update popup
as the ui was getting rendered before the popup apears this feature broke, instead of rebuilding it (by dynamically hiding/showing the menu item), I chose to just keep the item there always to keep the ui consistent. This will also allow user to update fishy without having to restart it when they do decide to update, instead of not able to find the update button.

#### other issues fixed:
- https://github.com/fishyboteso/fishyboteso/issues/75
now sends turn off signal instead

- https://github.com/fishyboteso/fishyboteso/issues/82
semifisher is only turned in player mode

- https://github.com/fishyboteso/fishyboteso/issues/31
window server thread now turns off when there are now window client instances, which are destroyed when engines are turned off 