### PR TITLE
decrease max human like delay

### DIFF
--- a/fishy/engine/semifisher/fishing_event.py
+++ b/fishy/engine/semifisher/fishing_event.py
@@ -34,7 +34,7 @@ class FishEvent:
     sound = False
 
 
-def _fishing_sleep(waittime, lower_limit_ms=16, upper_limit_ms=2500):
+def _fishing_sleep(waittime, lower_limit_ms=16, upper_limit_ms=1375):
     reaction = 0.0
     if FishEvent.jitter and upper_limit_ms > lower_limit_ms:
         reaction = float(random.randrange(lower_limit_ms, upper_limit_ms)) / 1000.0


### PR DESCRIPTION
This PR decreases the maximum time of the "human like" delay.
First of all it decreases the delay by 25%, according to the in game perk, that decreases the maximum by that value.
Additionally it decreases the delay by 500ms, which is the new default of FishyQR Updatetime.

close #105
close #81 