### PR TITLE
add short delay to give FishyQR keybind a heads up

### DIFF
--- a/fishy/engine/semifisher/engine.py
+++ b/fishy/engine/semifisher/engine.py
@@ -32,6 +32,7 @@ class SemiFisherEngine(IEngine):
             logging.info("Starting the bot engine, look at the fishing hole to start fishing")
             Thread(target=self._wait_and_check).start()
 
+        time.sleep(0.2)
         capture = self.window.get_capture()
         if capture is None:
             logging.error("couldn't get game capture")
@@ -66,10 +67,11 @@ class SemiFisherEngine(IEngine):
             values = get_values_from_image(capture)
             # if fishyqr fails to get read multiple times, stop the bot
             if not values:
-                skip_count += 1
                 if skip_count >= 5:
                     logging.error("Couldn't read values from FishyQR, Stopping engine...")
                     return
+                skip_count += 1
+                time.sleep(0.1)
             else:
                 skip_count = 0
 


### PR DESCRIPTION
This PR adds a short delay before the QR code is evaluated.

By adding an ingame keybind to toggle FishyQR with the same key as starting/stopping the bot (F9), it is possible to toggle both fishy-bot and FishyQR with one click. This might improve user experience a lot, since FishyQR is drawing a significant amount of CPU power on slower machines when enabled.
https://github.com/fishyboteso/FishyQR/commit/b8caf5d68348c0961638c13873cb8d26978a30e2
https://github.com/fishyboteso/FishyQR/commit/d99ced45c9e0ddb6cf190d9bebe9c34feb4e5662

To allow this mechanism to work, it is important that fishy-bot will not start reading the QR before FishyQR is enabled. Therefore a short delay of 200ms before the engine loop will give a heads up to FishyQR.

EDIT: this PR also adds a 100ms timeout to the engine loop everytime a qr read out was not successfull, this way certain grphical problems get a chance to fix themselves before another screenshot is evaluated.

I did not see any problems on my machine and this might even improve CPU load of fishy, due to less qr read outs in error cases.

