### PR TITLE
update fishy to 0.5.8 and fishyqr to 1.2.0

### DIFF
--- a/fishy/constants.py
+++ b/fishy/constants.py
@@ -5,7 +5,7 @@ chalutier = ("Chalutier", "https://www.esoui.com/downloads/dl2934/Chalutier_1.1.
 
 # addons used
 lam2 = ("LibAddonMenu-2.0", "https://www.esoui.com/downloads/dl7/LibAddonMenu-2.0r32.zip", 32)
-fishyqr = ("FishyQR", "https://github.com/fishyboteso/FishyQR/files/7575974/FishyQR.zip", 101)
+fishyqr = ("FishyQR", "https://github.com/fishyboteso/FishyQR/releases/download/v1.2.0/FishyQR.zip", 120)
 libgps = ("LibGPS", "https://cdn.esoui.com/downloads/file601/LibGPS_3_0_3.zip", 30)
 
-version = "0.5.7"
+version = "0.5.8"


### PR DESCRIPTION
This PR updates fishy to 0.5.8 and link of FishyQR to 1.2.0