### PR TITLE
fullauto player now waits for first loop of semifisher to complete before looking for hole

### DIFF
--- a/fishy/engine/fullautofisher/mode/player.py
+++ b/fishy/engine/fullautofisher/mode/player.py
@@ -91,6 +91,7 @@ class Player(IMode):
                 return
 
             self.engine.fisher.turn_on()
+            helper.wait_until(lambda: self.engine.fisher.first_loop_done)
             # scan for fish hole
             logging.info("scanning")
             # if found start fishing and wait for hole to complete

--- a/fishy/engine/semifisher/engine.py
+++ b/fishy/engine/semifisher/engine.py
@@ -23,6 +23,7 @@ class SemiFisherEngine(IEngine):
         self.window = None
         self.values = None
         self.name = "SemiFisher"
+        self.first_loop_done = False
 
     def run(self):
         """
@@ -53,6 +54,7 @@ class SemiFisherEngine(IEngine):
             print_exc()
 
         fishing_event.unsubscribe()
+        self.first_loop_done = False
 
     def _engine_loop(self):
         skip_count = 0
@@ -78,6 +80,7 @@ class SemiFisherEngine(IEngine):
 
             if self.values:
                 fishing_mode.loop(self.values[3])
+            self.first_loop_done = True
             time.sleep(0.1)
 
     def _wait_and_check(self):


### PR DESCRIPTION
Issue: #113

After turning on semi fisher, player directly checks if it can see the hole or not... If the semi fisher doesn't run fast enough to update the FishingMode.CurrentMode before player checks it, it will return false; resulting it in ignoring the hole