### PR TITLE
fix fullscreen fishy restart

### DIFF
--- a/fishy/gui/main_gui.py
+++ b/fishy/gui/main_gui.py
@@ -125,9 +125,13 @@ def _create(gui: 'GUI'):
 
     _apply_theme(gui)
     gui._root.update()
+
     gui._root.minsize(gui._root.winfo_width() + 10, gui._root.winfo_height() + 10)
     if config.get("win_loc") is not None:
-        gui._root.geometry(config.get("win_loc"))
+        gui._root.geometry(config.get("win_loc").split(":")[-1])
+        if config.get("win_loc").split(":")[0] == "zoomed":
+            gui._root.update()
+            gui._root.state("zoomed")
 
     hotkey.hook(Key.F9, gui.funcs.start_engine)
 
@@ -137,7 +141,13 @@ def _create(gui: 'GUI'):
             if not tk.messagebox.askyesno(title="Quit?", message="Bot engine running. Quit Anyway?"):
                 return
 
-        config.set("win_loc", gui._root.geometry())
+        if gui._root.state() == "zoomed":
+            # setting it to normal first is done to keep user-changed geometry values
+            gui._root.state("normal")
+            config.set("win_loc", "zoomed" + ":" + gui._root.geometry())
+        else:
+            config.set("win_loc", gui._root.state() + ":" + gui._root.geometry())
+
         gui._destroyed = True
 
     gui._root.protocol("WM_DELETE_WINDOW", set_destroy)

--- a/fishy/gui/splash.py
+++ b/fishy/gui/splash.py
@@ -32,6 +32,7 @@ def show(win_loc, q):
     # Position splash at the center of the main window
 
     default_loc = (str(top.winfo_reqwidth()) + "+" + str(top.winfo_reqheight()) + "+" + "0" + "0")
+    win_loc = win_loc.split(":")[-1]
     loc = (win_loc or default_loc).split("+")[1:]
     top.geometry("{}x{}+{}+{}".format(dim[0], dim[1], int(loc[0]) + int(dim[0] / 2), int(loc[1]) + int(dim[1] / 2)))
 


### PR DESCRIPTION
This PR overloads win_loc config with a zoomed keyword, to recover the zoomed state correctly on fishy reboot.

fixes #70